### PR TITLE
Let users customize sidebar footer order and visibility

### DIFF
--- a/apps/app/src/components/plugin/PluginSidebarFooterItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginSidebarFooterItems.test.tsx
@@ -5,7 +5,14 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import {
+  sidebarFooterOrderAtom,
+  sidebarFooterHiddenAtom,
+} from "@/components/sidebar/sidebarFooterPreferences";
+import { SidebarFooterSettings } from "@/components/settings/SidebarFooterSettings";
 import type { ReactNode } from "react";
 import type {
   ExperimentalSidebarFooterActionContext,
@@ -17,6 +24,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { SidebarMenu, SidebarProvider } from "@/components/ui/sidebar.js";
 import {
   resetPluginSlotStoreForTest,
+  removePluginSlotRegistrations,
   setPluginSlotRegistrations,
   type PluginRegistrationSet,
 } from "@/lib/plugin-slots";
@@ -59,16 +67,18 @@ function LocationProbe() {
   );
 }
 
-function renderWithProviders(ui: ReactNode) {
+function renderWithProviders(ui: ReactNode, store = createStore()) {
   return render(
-    <MemoryRouter>
-      <TooltipProvider delayDuration={0}>
-        <SidebarProvider>
-          {ui}
-          <LocationProbe />
-        </SidebarProvider>
-      </TooltipProvider>
-    </MemoryRouter>,
+    <Provider store={store}>
+      <MemoryRouter>
+        <TooltipProvider delayDuration={0}>
+          <SidebarProvider>
+            {ui}
+            <LocationProbe />
+          </SidebarProvider>
+        </TooltipProvider>
+      </MemoryRouter>
+    </Provider>,
   );
 }
 
@@ -372,5 +382,192 @@ describe("PluginSidebarFooterItems", () => {
 
     fireEvent.keyDown(window, { key: "Escape" });
     expect(screen.queryByText("First content")).toBeNull();
+  });
+
+  it("moves an open disclosure into More, still opens it there, and restores it through appearance settings", async () => {
+    const definition = definePluginApp((app) => {
+      app.experimental_sidebarFooter.register({
+        kind: "disclosure",
+        id: "usage",
+        label: "Provider usage",
+        icon: "ChartColumn",
+        component: () => <p>Usage detail</p>,
+      });
+    });
+    setPluginSlotRegistrations(
+      "usage-plugin",
+      collectPluginAppRegistrations(definition),
+    );
+    const store = createStore();
+    renderWithProviders(
+      <>
+        <FooterHarness />
+        <SidebarFooterSettings />
+      </>,
+      store,
+    );
+    expect(
+      screen.queryByRole("button", { name: "More footer actions" }),
+    ).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Provider usage" }));
+    expect(screen.getByText("Usage detail")).toBeDefined();
+    fireEvent.contextMenu(
+      screen.getByRole("button", { name: "Provider usage" }),
+    );
+    fireEvent.pointerUp(
+      await screen.findByRole("menuitem", { name: "Customize footer" }),
+      { button: 2, pointerType: "mouse" },
+    );
+    expect(screen.getByLabelText("Current path").textContent).toBe("/");
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Hide" }));
+    await waitFor(() => expect(screen.queryByText("Usage detail")).toBeNull());
+    expect(store.get(sidebarFooterHiddenAtom)).toEqual([
+      "plugin:usage-plugin/usage",
+    ]);
+    expect(screen.queryByRole("button", { name: "Provider usage" })).toBeNull();
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "More footer actions" }),
+      { button: 0, ctrlKey: false, pointerType: "mouse" },
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Provider usage" }),
+    );
+    await screen.findByText("Usage detail");
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() =>
+      expect(document.activeElement?.id).toBe("sidebar-footer-more"),
+    );
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Show Provider usage in footer" }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Provider usage" }),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("button", { name: "More footer actions" }),
+    ).toBeNull();
+  });
+
+  it("keeps hidden actions callable and preserves preferences across plugin reloads", async () => {
+    const run = vi.fn();
+    const registration = collectPluginAppRegistrations(
+      definePluginApp((app) => {
+        app.experimental_sidebarFooter.register({
+          kind: "action",
+          id: "action",
+          label: "Run action",
+          icon: "Zap",
+          onActivate: run,
+        });
+      }),
+    );
+    setPluginSlotRegistrations("example", registration);
+    const store = createStore();
+    store.set(sidebarFooterHiddenAtom, ["plugin:example/action"]);
+    store.set(sidebarFooterOrderAtom, [
+      "plugin:missing/item",
+      "plugin:example/action",
+    ]);
+    renderWithProviders(<FooterHarness />, store);
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "More footer actions" }),
+      { button: 0, ctrlKey: false, pointerType: "mouse" },
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Run action" }),
+    );
+    expect(run).toHaveBeenCalledTimes(1);
+    act(() => removePluginSlotRegistrations("example"));
+    expect(
+      screen.queryByRole("button", { name: "More footer actions" }),
+    ).toBeNull();
+    act(() =>
+      setPluginSlotRegistrations(
+        "new-plugin",
+        collectPluginAppRegistrations(
+          definePluginApp((app) => {
+            app.experimental_sidebarFooter.register({
+              kind: "action",
+              id: "new",
+              label: "New action",
+              icon: "Zap",
+              onActivate: run,
+            });
+          }),
+        ),
+      ),
+    );
+    expect(screen.getByRole("button", { name: "New action" })).toBeDefined();
+    act(() => setPluginSlotRegistrations("example", registration));
+    expect(screen.queryByRole("button", { name: "Run action" })).toBeNull();
+    expect(store.get(sidebarFooterHiddenAtom)).toEqual([
+      "plugin:example/action",
+    ]);
+    expect(store.get(sidebarFooterOrderAtom)).toEqual([
+      "plugin:missing/item",
+      "plugin:example/action",
+    ]);
+  });
+
+  it("orders built-in and plugin shortcuts together and keeps all-hidden actions reachable", async () => {
+    const run = vi.fn();
+    setPluginSlotRegistrations(
+      "example",
+      collectPluginAppRegistrations(
+        definePluginApp((app) => {
+          app.experimental_sidebarFooter.register({
+            kind: "action",
+            id: "action",
+            label: "Run action",
+            icon: "Zap",
+            onActivate: run,
+          });
+        }),
+      ),
+    );
+    const store = createStore();
+    store.set(sidebarFooterOrderAtom, [
+      "builtin:report-bug",
+      "plugin:example/action",
+      "builtin:settings",
+    ]);
+    const view = renderWithProviders(
+      <SidebarMenu>
+        <PluginSidebarFooterItems
+          activeDisclosureKey={null}
+          onDisclosureCommand={vi.fn()}
+          builtInActions={[
+            { id: "settings", onActivate: run },
+            { id: "report-bug", onActivate: run },
+          ]}
+        />
+      </SidebarMenu>,
+      store,
+    );
+    expect(
+      [...view.container.querySelectorAll("[data-footer-item]")].map((item) =>
+        item.getAttribute("data-footer-item"),
+      ),
+    ).toEqual([
+      "builtin:report-bug",
+      "plugin:example/action",
+      "builtin:settings",
+    ]);
+    act(() =>
+      store.set(sidebarFooterHiddenAtom, [
+        "builtin:settings",
+        "builtin:report-bug",
+        "plugin:example/action",
+      ]),
+    );
+    expect(view.container.querySelectorAll("[data-footer-item]")).toHaveLength(
+      0,
+    );
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "More footer actions" }),
+      { button: 0, ctrlKey: false, pointerType: "mouse" },
+    );
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Settings" }));
+    expect(run).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/app/src/components/plugin/PluginSidebarFooterItems.tsx
+++ b/apps/app/src/components/plugin/PluginSidebarFooterItems.tsx
@@ -7,7 +7,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import type { ExperimentalSidebarFooterCommandKind } from "@get-bb/plugin-sdk/internal/plugin-app-collector";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { COARSE_POINTER_CHILD_ICON_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
@@ -19,7 +19,30 @@ import {
   usePluginSlots,
   type PluginSidebarFooterItemSlot,
 } from "@/lib/plugin-slots";
-import { getPluginConfigurationRoutePath } from "@/lib/route-paths";
+import {
+  getSettingsRoutePath,
+  getPluginConfigurationRoutePath,
+} from "@/lib/route-paths";
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@bb/shared-ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@bb/shared-ui/dropdown-menu";
+import {
+  useSidebarFooterPreferences,
+  SIDEBAR_FOOTER_MORE_ID,
+  type FooterItem,
+  type BuiltinFooterId,
+} from "@/components/sidebar/sidebarFooterPreferences";
 
 const SIDEBAR_FOOTER_ACTION_CLASS = cn(
   COARSE_POINTER_CHILD_ICON_BUTTON_CLASS,
@@ -90,9 +113,10 @@ export function usePluginSidebarFooterDisclosure() {
 
   useLayoutEffect(() => {
     if (restoreFocusItem === null || activeItem !== null) return;
-    document
-      .getElementById(footerTriggerId(restoreFocusItem))
-      ?.focus({ preventScroll: true });
+    (
+      document.getElementById(footerTriggerId(restoreFocusItem)) ??
+      document.getElementById(SIDEBAR_FOOTER_MORE_ID)
+    )?.focus({ preventScroll: true });
   }, [activeItem, restoreFocusItem]);
 
   useEffect(() => {
@@ -159,10 +183,19 @@ export function PluginSidebarFooterDisclosure({
   );
 }
 
+export interface BuiltinFooterAction {
+  id: BuiltinFooterId;
+  onActivate(): void;
+  href?: string;
+  ariaLabel?: string;
+  ariaKeyShortcuts?: string;
+}
+
 export function PluginSidebarFooterItems({
   activeDisclosureKey,
   onDisclosureCommand,
   onNavigate,
+  builtInActions = [],
 }: {
   activeDisclosureKey: string | null;
   onDisclosureCommand: (
@@ -171,117 +204,232 @@ export function PluginSidebarFooterItems({
     sequence?: number,
   ) => void;
   onNavigate?: () => void;
+  builtInActions?: readonly BuiltinFooterAction[];
 }) {
-  const { sidebarFooterItems } = usePluginSlots();
-  if (sidebarFooterItems.length === 0) return null;
+  const navigate = useNavigate();
+  const preferences = useSidebarFooterPreferences();
+  const previousHidden = useRef(preferences.hidden);
+  const items = preferences.items.filter(
+    (item) =>
+      item.kind === "plugin" ||
+      builtInActions.some((action) => action.id === item.id),
+  );
+  const hidden = items.filter((item) => preferences.hidden.includes(item.key));
+  useEffect(() => {
+    for (const item of items) {
+      if (
+        item.kind === "plugin" &&
+        item.slot.kind === "disclosure" &&
+        preferences.hidden.includes(item.key) &&
+        !previousHidden.current.includes(item.key)
+      ) {
+        onDisclosureCommand(footerItemKey(item.slot), "close");
+      }
+    }
+    previousHidden.current = preferences.hidden;
+  }, [items, preferences.hidden, onDisclosureCommand]);
+
+  function activate(item: FooterItem) {
+    if (item.kind === "builtin") {
+      builtInActions.find((action) => action.id === item.id)?.onActivate();
+      return;
+    }
+    const slot = item.slot;
+    if (slot.kind === "disclosure") {
+      onDisclosureCommand(footerItemKey(slot), "toggle");
+      return;
+    }
+    onNavigate?.();
+    runContainedFooterCallback(
+      slot.pluginId,
+      slot.source === "sidebarFooterAction"
+        ? `sidebarFooterAction "${slot.id}"`
+        : `experimental_sidebarFooter item "${slot.id}"`,
+      () =>
+        slot.onActivate({
+          openPluginDetails: () => {
+            void navigate(
+              getPluginConfigurationRoutePath({ pluginId: slot.pluginId }),
+            );
+          },
+        }),
+    );
+  }
+  function customize() {
+    onNavigate?.();
+    void navigate(getSettingsRoutePath("appearance"));
+  }
   return (
     <>
-      {sidebarFooterItems.map((item) => (
-        <SidebarFooterItemButton
-          key={footerItemKey(item)}
-          item={item}
-          isActive={footerItemKey(item) === activeDisclosureKey}
-          onDisclosureCommand={onDisclosureCommand}
-          onNavigate={onNavigate}
-        />
-      ))}
+      {items.map((item) =>
+        item.kind === "plugin" ? (
+          <FooterCommandObserver
+            key={footerItemKey(item.slot)}
+            item={item.slot}
+            onDisclosureCommand={onDisclosureCommand}
+          />
+        ) : null,
+      )}
+      {items
+        .filter((item) => !preferences.hidden.includes(item.key))
+        .map((item) => {
+          const builtin =
+            item.kind === "builtin"
+              ? builtInActions.find((action) => action.id === item.id)
+              : undefined;
+          const active =
+            item.kind === "plugin" &&
+            footerItemKey(item.slot) === activeDisclosureKey;
+          const label = builtin?.ariaLabel ?? item.label;
+          return (
+            <ContextMenu key={item.key}>
+              <ContextMenuTrigger asChild>
+                <SidebarMenuItem
+                  className="min-w-0"
+                  data-footer-item={item.key}
+                >
+                  <SidebarMenuButton
+                    asChild={builtin?.href !== undefined}
+                    id={
+                      item.kind === "plugin"
+                        ? footerTriggerId(item.slot)
+                        : `sidebar-footer-${item.id}`
+                    }
+                    aria-label={label}
+                    aria-keyshortcuts={builtin?.ariaKeyShortcuts}
+                    tooltip={{ children: label, hidden: false, side: "top" }}
+                    className={cn(
+                      SIDEBAR_FOOTER_ACTION_CLASS,
+                      active &&
+                        "bg-sidebar-accent text-sidebar-accent-foreground [&>svg]:opacity-100",
+                    )}
+                    data-testid={
+                      item.kind === "plugin"
+                        ? item.slot.source === "sidebarFooterAction"
+                          ? `plugin-sidebar-footer-action-${item.slot.pluginId}-${item.slot.id}`
+                          : `plugin-sidebar-footer-item-${item.slot.pluginId}-${item.slot.id}`
+                        : undefined
+                    }
+                    {...(item.kind === "plugin" &&
+                    item.slot.kind === "disclosure"
+                      ? {
+                          "aria-expanded": active,
+                          "aria-controls": footerDisclosureId(item.slot),
+                        }
+                      : {})}
+                    onClick={
+                      builtin?.href === undefined
+                        ? () => activate(item)
+                        : undefined
+                    }
+                  >
+                    {builtin?.href !== undefined ? (
+                      <Link to={builtin.href} onClick={onNavigate}>
+                        <FooterItemIcon item={item} />
+                        <span className="sr-only">{item.label}</span>
+                      </Link>
+                    ) : (
+                      <>
+                        <FooterItemIcon item={item} />
+                        <span className="sr-only">{item.label}</span>
+                      </>
+                    )}
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </ContextMenuTrigger>
+              <ContextMenuContent
+                onPointerUpCapture={(event) => {
+                  if (event.button !== 0) event.preventDefault();
+                }}
+              >
+                <ContextMenuItem
+                  onSelect={() => preferences.setVisible(item.key, false)}
+                >
+                  <Icon name="EyeOff" />
+                  Hide
+                </ContextMenuItem>
+                <ContextMenuItem onSelect={customize}>
+                  Customize footer
+                </ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu>
+          );
+        })}
+      {hidden.length > 0 ? (
+        <SidebarMenuItem className="min-w-0">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <SidebarMenuButton
+                id={SIDEBAR_FOOTER_MORE_ID}
+                aria-label="More footer actions"
+                tooltip={{ children: "More", hidden: false, side: "top" }}
+                className={SIDEBAR_FOOTER_ACTION_CLASS}
+              >
+                <Icon name="MoreHorizontal" />
+                <span className="sr-only">More</span>
+              </SidebarMenuButton>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              side="top"
+              align="start"
+              mobileTitle="More footer actions"
+            >
+              {hidden.map((item) => (
+                <DropdownMenuItem
+                  key={item.key}
+                  onSelect={() => activate(item)}
+                >
+                  <FooterItemIcon item={item} />
+                  {item.label}
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={customize}>
+                Customize footer
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </SidebarMenuItem>
+      ) : null}
     </>
   );
 }
 
-function SidebarFooterItemButton({
+function FooterCommandObserver({
   item,
-  isActive,
   onDisclosureCommand,
-  onNavigate,
 }: {
   item: PluginSidebarFooterItemSlot;
-  isActive: boolean;
   onDisclosureCommand: (
-    itemKey: string,
+    key: string,
     command: ExperimentalSidebarFooterCommandKind,
     sequence?: number,
   ) => void;
-  onNavigate?: () => void;
 }) {
-  const navigate = useNavigate();
   const snapshot = useSyncExternalStore(
     item.runtime.subscribe,
     item.runtime.getSnapshot,
     item.runtime.getSnapshot,
   );
   const command = snapshot.command;
-  const itemKey = footerItemKey(item);
-
   useEffect(() => {
     if (command === null || item.kind !== "disclosure") return;
-    onDisclosureCommand(itemKey, command.kind, command.sequence);
+    onDisclosureCommand(footerItemKey(item), command.kind, command.sequence);
     item.runtime.acknowledgeCommand(command.sequence);
-  }, [command, item, itemKey, onDisclosureCommand]);
+  }, [command, item, onDisclosureCommand]);
+  return null;
+}
 
-  return (
-    <SidebarMenuItem className="min-w-0">
-      <SidebarMenuButton
-        id={footerTriggerId(item)}
-        type="button"
-        aria-label={item.label}
-        tooltip={{
-          children: item.label,
-          hidden: false,
-          side: "top",
-        }}
-        className={cn(
-          SIDEBAR_FOOTER_ACTION_CLASS,
-          isActive &&
-            "bg-sidebar-accent text-sidebar-accent-foreground [&>svg]:opacity-100",
-        )}
-        data-testid={
-          item.source === "sidebarFooterAction"
-            ? `plugin-sidebar-footer-action-${item.pluginId}-${item.id}`
-            : `plugin-sidebar-footer-item-${item.pluginId}-${item.id}`
-        }
-        {...(item.kind === "disclosure"
-          ? {
-              "aria-expanded": isActive,
-              "aria-controls": footerDisclosureId(item),
-            }
-          : {})}
-        onClick={() => {
-          if (item.kind === "disclosure") {
-            onDisclosureCommand(itemKey, "toggle");
-            return;
-          }
-          onNavigate?.();
-          runContainedFooterCallback(
-            item.pluginId,
-            item.source === "sidebarFooterAction"
-              ? `sidebarFooterAction "${item.id}"`
-              : `experimental_sidebarFooter item "${item.id}"`,
-            () =>
-              item.onActivate({
-                openPluginDetails: () => {
-                  void navigate(
-                    getPluginConfigurationRoutePath({
-                      pluginId: item.pluginId,
-                    }),
-                  );
-                },
-              }),
-          );
-        }}
-      >
-        {item.source === "sidebarFooterAction" ? (
-          <PluginIcon pluginId={item.pluginId} icon={item.icon} />
-        ) : (
-          <Icon
-            name={pluginIconName(item.icon)}
-            className="size-4 shrink-0"
-            aria-hidden="true"
-          />
-        )}
-        <span className="sr-only">{item.label}</span>
-      </SidebarMenuButton>
-    </SidebarMenuItem>
+export function FooterItemIcon({ item }: { item: FooterItem }) {
+  return item.kind === "plugin" &&
+    item.slot.source === "sidebarFooterAction" ? (
+    <PluginIcon pluginId={item.slot.pluginId} icon={item.icon} />
+  ) : (
+    <Icon
+      name={pluginIconName(item.icon)}
+      className="size-4 shrink-0"
+      aria-hidden="true"
+    />
   );
 }
 

--- a/apps/app/src/components/settings/SidebarFooterSettings.tsx
+++ b/apps/app/src/components/settings/SidebarFooterSettings.tsx
@@ -1,0 +1,101 @@
+import { DndContext } from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { Icon } from "@bb/shared-ui/icon";
+import { Button } from "@bb/shared-ui/button";
+import { Switch } from "@bb/shared-ui/switch";
+import { SettingsWithControl } from "@/components/ui/settings-section";
+import { useReorderDnd } from "@/components/ui/useReorderDnd";
+import { useSidebarSortable } from "@/components/sidebar/sortableMotion";
+import {
+  useSidebarFooterPreferences,
+  type FooterItem,
+} from "@/components/sidebar/sidebarFooterPreferences";
+import { FooterItemIcon } from "@/components/plugin/PluginSidebarFooterItems";
+
+export function SidebarFooterSettings() {
+  const preferences = useSidebarFooterPreferences();
+  const { dndContextProps, onClickCapture } = useReorderDnd({
+    onDragEnd(event) {
+      if (
+        typeof event.active.id === "string" &&
+        typeof event.over?.id === "string"
+      )
+        preferences.move(event.active.id, event.over.id);
+    },
+  });
+  return (
+    <SettingsWithControl
+      label="Sidebar footer"
+      description="Drag to reorder. Hidden actions remain available in the footer’s More menu."
+      controlPlacement="below"
+    >
+      <div
+        className="rounded-md border border-border"
+        onClickCapture={onClickCapture}
+      >
+        <DndContext {...dndContextProps}>
+          <SortableContext
+            items={preferences.items.map((item) => item.key)}
+            strategy={verticalListSortingStrategy}
+          >
+            {preferences.items.map((item) => (
+              <FooterSettingsRow
+                key={item.key}
+                item={item}
+                visible={!preferences.hidden.includes(item.key)}
+                onVisibleChange={(visible) =>
+                  preferences.setVisible(item.key, visible)
+                }
+              />
+            ))}
+          </SortableContext>
+        </DndContext>
+      </div>
+    </SettingsWithControl>
+  );
+}
+
+function FooterSettingsRow({
+  item,
+  visible,
+  onVisibleChange,
+}: {
+  item: FooterItem;
+  visible: boolean;
+  onVisibleChange(visible: boolean): void;
+}) {
+  const { dragBindings, setNodeRef, style } = useSidebarSortable({
+    id: item.key,
+    disabled: false,
+  });
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-2 border-b border-border px-2 py-2 last:border-b-0"
+      data-footer-setting={item.key}
+    >
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-7 touch-none text-muted-foreground"
+        ref={dragBindings.setActivatorNodeRef}
+        {...dragBindings.attributes}
+        {...dragBindings.listeners}
+        aria-label={`Reorder ${item.label}`}
+      >
+        <Icon name="DragDropVertical" className="size-4" />
+      </Button>
+      <FooterItemIcon item={item} />
+      <span className="min-w-0 flex-1 truncate text-sm">{item.label}</span>
+      <Switch
+        checked={visible}
+        onCheckedChange={onVisibleChange}
+        aria-label={`Show ${item.label} in footer`}
+      />
+    </div>
+  );
+}

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { THREAD_JUMP_APP_COMMAND_IDS } from "@bb/domain";
-import { Link, useNavigate } from "react-router-dom";
-import { Icon } from "@bb/shared-ui/icon";
+import { useNavigate } from "react-router-dom";
 import { COARSE_POINTER_CHILD_ICON_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { OverflowFade } from "@/components/ui/overflow-fade.js";
 import {
@@ -10,8 +9,6 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
   useCloseMobileSidebar,
   useSidebar,
 } from "@/components/ui/sidebar.js";
@@ -279,53 +276,32 @@ export function AppSidebar({
           onDismiss={pluginSidebarFooter.dismiss}
         />
         <SidebarMenu className="flex-row flex-wrap-reverse items-center gap-1">
-          <SidebarMenuItem className="min-w-0">
-            <SidebarMenuButton
-              asChild
-              aria-label={
-                settingsShortcut
-                  ? `Settings (${settingsShortcut.label})`
-                  : "Settings"
-              }
-              aria-keyshortcuts={settingsShortcut?.ariaKeyshortcuts}
-              tooltip={{
-                children: settingsShortcut
-                  ? `Settings (${settingsShortcut.label})`
-                  : "Settings",
-                hidden: false,
-                side: "top",
-              }}
-              className={SIDEBAR_FOOTER_ACTION_CLASS}
-            >
-              <Link to={settingsRoutePath} onClick={closeOnMobile}>
-                <Icon name="Settings" />
-                <span className="sr-only">Settings</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
           <PluginSidebarFooterItems
             activeDisclosureKey={pluginSidebarFooter.activeKey}
             onDisclosureCommand={pluginSidebarFooter.handleCommand}
             onNavigate={closeOnMobile}
+            builtInActions={[
+              {
+                id: "settings",
+                href: settingsRoutePath,
+                ariaLabel: settingsShortcut
+                  ? `Settings (${settingsShortcut.label})`
+                  : "Settings",
+                ariaKeyShortcuts: settingsShortcut?.ariaKeyshortcuts,
+                onActivate: () => {
+                  closeOnMobile();
+                  void navigate(settingsRoutePath);
+                },
+              },
+              {
+                id: "report-bug",
+                onActivate: () => {
+                  closeOnMobile();
+                  openUrlInExternalBrowser(BUG_REPORT_NEW_ISSUE_URL);
+                },
+              },
+            ]}
           />
-          <SidebarMenuItem className="min-w-0">
-            <SidebarMenuButton
-              className={SIDEBAR_FOOTER_ACTION_CLASS}
-              tooltip={{
-                children: "Report a bug",
-                hidden: false,
-                side: "top",
-              }}
-              aria-label="Report a bug"
-              onClick={() => {
-                closeOnMobile();
-                openUrlInExternalBrowser(BUG_REPORT_NEW_ISSUE_URL);
-              }}
-            >
-              <Icon name="Bug" />
-              <span className="sr-only">Report a bug</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
           <li aria-hidden="true" className="min-w-0 flex-1" />
           <SidebarPluginAttentionGlyph
             className={SIDEBAR_FOOTER_ACTION_CLASS}

--- a/apps/app/src/components/sidebar/sidebarFooterPreferences.ts
+++ b/apps/app/src/components/sidebar/sidebarFooterPreferences.ts
@@ -1,0 +1,81 @@
+import { useAtom } from "jotai";
+import {
+  usePluginSlots,
+  type PluginSidebarFooterItemSlot,
+} from "@/lib/plugin-slots";
+import { createSyncedPreferenceAtom } from "@/lib/ui-preferences/synced-preference-atom";
+import { arrangeByStoredOrder, reorderStoredOrder } from "@/lib/stored-order";
+
+export const sidebarFooterOrderAtom = createSyncedPreferenceAtom(
+  "sidebar.footerOrder",
+);
+export const sidebarFooterHiddenAtom = createSyncedPreferenceAtom(
+  "sidebar.hiddenFooterItems",
+);
+export const SIDEBAR_FOOTER_MORE_ID = "sidebar-footer-more";
+
+export type BuiltinFooterId = "settings" | "report-bug";
+export type FooterItem = { key: string; label: string; icon: string } & (
+  | { kind: "builtin"; id: BuiltinFooterId }
+  | { kind: "plugin"; slot: PluginSidebarFooterItemSlot }
+);
+export function footerPreferenceKey(item: {
+  pluginId: string;
+  id: string;
+}): string {
+  return `plugin:${encodeURIComponent(item.pluginId)}/${encodeURIComponent(item.id)}`;
+}
+
+export function useSidebarFooterPreferences() {
+  const { sidebarFooterItems } = usePluginSlots();
+  const [order, setOrder] = useAtom(sidebarFooterOrderAtom);
+  const [hidden, setHidden] = useAtom(sidebarFooterHiddenAtom);
+  const items: FooterItem[] = [
+    {
+      kind: "builtin",
+      id: "settings",
+      key: "builtin:settings",
+      label: "Settings",
+      icon: "Settings",
+    },
+    ...sidebarFooterItems.map((slot): FooterItem => ({
+      kind: "plugin",
+      key: footerPreferenceKey(slot),
+      label: slot.label,
+      icon: slot.icon,
+      slot,
+    })),
+    {
+      kind: "builtin",
+      id: "report-bug",
+      key: "builtin:report-bug",
+      label: "Report a bug",
+      icon: "Bug",
+    },
+  ];
+  const { ordered, normalizedOrder } = arrangeByStoredOrder({
+    items,
+    storedOrder: order,
+    getId: (item) => item.key,
+  });
+  return {
+    items: ordered,
+    hidden,
+    setVisible(key: string, visible: boolean) {
+      setHidden((previous) =>
+        visible
+          ? previous.filter((id) => id !== key)
+          : [...new Set([...previous, key])],
+      );
+    },
+    move(activeId: string, overId: string) {
+      const next = reorderStoredOrder({
+        activeId,
+        overId,
+        order: normalizedOrder,
+        visibleIds: ordered.map((item) => item.key),
+      });
+      if (next) setOrder(next);
+    },
+  };
+}

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -51,6 +51,7 @@ import { UsageLimitsSettingsSection } from "@/components/settings/UsageLimitsSet
 import { ProvidersSettingsSection } from "@/components/settings/ProvidersSettingsSection";
 import { CodeRendererSettings } from "@/components/settings/CodeRendererSettings";
 import { SidebarThreadListSetting } from "@/components/settings/SidebarThreadListSetting";
+import { SidebarFooterSettings } from "@/components/settings/SidebarFooterSettings";
 import { SidebarNavigationSetting } from "@/components/settings/SidebarNavigationSetting";
 import { SplitDimmingSetting } from "@/components/settings/SplitDimmingSetting";
 import { useSettingsNavState } from "@/components/settings/settings-nav";
@@ -700,6 +701,7 @@ export function AppearanceSettingsSection({
       <div className="space-y-5">
         <SidebarThreadListSetting />
         <SidebarNavigationSetting />
+        <SidebarFooterSettings />
         <CodeRendererSettings />
         <SettingsWithControl label="Theme">
           <DropdownMenu>

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -701,7 +701,6 @@ export function AppearanceSettingsSection({
       <div className="space-y-5">
         <SidebarThreadListSetting />
         <SidebarNavigationSetting />
-        <SidebarFooterSettings />
         <CodeRendererSettings />
         <SettingsWithControl label="Theme">
           <DropdownMenu>
@@ -833,6 +832,7 @@ export function AppearanceSettingsSection({
           onFaviconColorChange={onFaviconColorChange}
         />
         <SplitDimmingSetting />
+        <SidebarFooterSettings />
       </div>
     </SettingsSection>
   );

--- a/apps/server/test/public/public-ui-preferences.test.ts
+++ b/apps/server/test/public/public-ui-preferences.test.ts
@@ -29,6 +29,36 @@ async function resetPreference(
 }
 
 describe("public ui preferences", () => {
+  it("retains unavailable footer IDs and rejects malformed footer preferences", async () => {
+    await withTestHarness(async (harness) => {
+      for (const key of ["sidebar.footerOrder", "sidebar.hiddenFooterItems"]) {
+        const value = [
+          "plugin:disabled%2Fplugin/item%2Fid",
+          "builtin:settings",
+          "plugin:unknown/item",
+        ];
+        expect(
+          (await putPreference(harness, key, { expectedRevision: 0, value }))
+            .status,
+        ).toBe(200);
+        expect(await readJson(await listPreferences(harness))).toMatchObject({
+          preferences: { [key]: { value, revision: 1 } },
+        });
+        expect(
+          (
+            await putPreference(harness, key, {
+              expectedRevision: 1,
+              value: [12],
+            })
+          ).status,
+        ).toBe(400);
+        expect(
+          await readJson(await resetPreference(harness, key)),
+        ).toMatchObject({ value: [] });
+      }
+    });
+  });
+
   it("adds sort direction without replacing an existing sort field and can reset it", async () => {
     await withTestHarness(async (harness) => {
       expect(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -629,6 +629,8 @@ client wrote first, so a stale window cannot silently clobber a newer value.
 | `sidebar.collapsedEnvironments`   | Collapsed environment ids                           |
 | `sidebar.collapsedThreadSections` | Collapsed thread section ids                        |
 | `sidebar.collapsedMachines`       | Collapsed machine ids                               |
+| `sidebar.footerOrder`             | Footer action order                                 |
+| `sidebar.hiddenFooterItems`       | Footer actions moved into More                      |
 | `sidebar.pluginPanelOrder`        | Navigation entry order                              |
 | `sidebar.visiblePluginPanels`     | Navigation entries shown, or `null` for every entry |
 | `sidebar.navigationProvider`      | Plugin key, `__automatic__`, or `__builtin__`       |
@@ -663,6 +665,25 @@ value. A change on one device reaches every other connected window through the
 
 Sidebar width and open state stay in the browser because they depend on the
 window size.
+
+### Sidebar footer
+
+Settings → Appearance → Sidebar footer lets users reorder and hide built-in and
+registered plugin actions. Right-click an action and choose Hide to move it into
+More. More appears only when registered actions are hidden; they remain usable.
+Hiding an open disclosure closes it; selecting it from More opens it again.
+
+The UI preferences `sidebar.footerOrder` and `sidebar.hiddenFooterItems` contain
+stable IDs: `builtin:settings`, `builtin:report-bug`, and
+`plugin:<encoded pluginId>/<encoded registrationId>` (URI-encoded components).
+Unknown and disabled-plugin IDs are retained across reloads; new actions default
+visible. The existing SDK UI preferences and CLI manage the same values:
+
+```sh
+bb settings ui set sidebar.hiddenFooterItems '["builtin:report-bug"]'
+bb settings ui set sidebar.footerOrder '["builtin:report-bug","builtin:settings"]'
+bb settings ui reset sidebar.hiddenFooterItems
+```
 
 ## Thread splits
 

--- a/packages/domain/src/ui-preferences.ts
+++ b/packages/domain/src/ui-preferences.ts
@@ -45,6 +45,8 @@ export const UI_PREFERENCE_KEYS = [
   "sidebar.collapsedEnvironments",
   "sidebar.collapsedThreadSections",
   "sidebar.collapsedMachines",
+  "sidebar.footerOrder",
+  "sidebar.hiddenFooterItems",
   "sidebar.pluginPanelOrder",
   "sidebar.visiblePluginPanels",
   "sidebar.navigationProvider",
@@ -133,6 +135,16 @@ export const uiPreferenceDefinitions = {
     uiPreferenceStringListSchema,
     [],
     "Machine ids whose sidebar rows are collapsed.",
+  ),
+  "sidebar.footerOrder": defineUiPreference(
+    uiPreferenceStringListSchema,
+    [],
+    "Order of built-in and plugin sidebar footer actions.",
+  ),
+  "sidebar.hiddenFooterItems": defineUiPreference(
+    uiPreferenceStringListSchema,
+    [],
+    "Sidebar footer actions moved into the More menu.",
   ),
   "sidebar.pluginPanelOrder": defineUiPreference(
     uiPreferenceStringListSchema,

--- a/packages/plugin-api-map/src/anatomy-manifest.json
+++ b/packages/plugin-api-map/src/anatomy-manifest.json
@@ -156,8 +156,8 @@
         {
           "path": "apps/app/src/components/plugin/PluginSidebarFooterItems.tsx",
           "anchors": [
-            "\"aria-expanded\": isActive",
-            "onDisclosureCommand(itemKey, \"toggle\")",
+            "\"aria-expanded\": active",
+            "onDisclosureCommand(footerItemKey(slot), \"toggle\")",
             "<Component dismiss={onDismiss} />"
           ]
         },

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -121,6 +121,7 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
         bullets: [
           "Run an action, or reveal plugin-rendered content above the footer row",
           "Let bb coordinate one open disclosure across every enabled plugin",
+          "Respect user ordering and visibility in Appearance; hidden actions and disclosures remain usable from More",
           "Keep navigation, tabs, data, and controls inside the plugin's disclosure component",
         ],
         apiSymbols: [

--- a/packages/templates/src/templates/bb-guide-customization.md
+++ b/packages/templates/src/templates/bb-guide-customization.md
@@ -247,6 +247,20 @@ Sort by selects a field, and selecting it again reverses its arrow/direction.
 The default preserves each field's original order (newest first for dates,
 A–Z for titles). For example: `bb settings ui set sidebar.sortDirection ascending`.
 
+Sidebar footer actions
+
+Settings → Appearance → Sidebar footer supports drag ordering and visibility.
+Right-click an action and choose Hide to move it into the More menu. Hidden
+shortcuts remain actionable; hiding an open disclosure closes it. The More menu
+appears only when hidden actions are available and links back to customization.
+`sidebar.footerOrder` and `sidebar.hiddenFooterItems` are string lists. Keys are
+`builtin:settings`, `builtin:report-bug`, or `plugin:<encoded pluginId>/<encoded registrationId>`.
+Preferences survive plugin reloads and temporarily unavailable plugins; new items
+are visible by default. Example:
+
+  bb settings ui set sidebar.hiddenFooterItems '["plugin:provider-usage/usage"]'
+  bb settings ui reset sidebar.hiddenFooterItems
+
 Client-local UI preferences
 
 Some Settings values live only in the current browser/client. Sidebar width

--- a/plugins/bb-guide/skills/bb-cli/references/app-settings.md
+++ b/plugins/bb-guide/skills/bb-cli/references/app-settings.md
@@ -156,3 +156,11 @@ server gh credentials to machines; `true` enables them again. In Machines →
 Advanced settings, the automatic GH_TOKEN switch controls the same setting.
 This does not log the server out or suppress an explicit custom GH_TOKEN.
 Changes apply to new turns, setup commands and terminals.
+
+Sidebar footer actions use `sidebar.footerOrder` and `sidebar.hiddenFooterItems`.
+Both are string lists shared across clients. Keys are `builtin:settings`,
+`builtin:report-bug`, or `plugin:<encoded pluginId>/<encoded registrationId>`.
+Right-click Hide moves an action into More; Settings → Appearance → Sidebar footer
+restores visibility and drag-reorders actions. CLI example:
+`bb settings ui set sidebar.hiddenFooterItems '["plugin:provider-usage/usage"]'`.
+Use `bb settings ui reset sidebar.hiddenFooterItems` to show everything again.


### PR DESCRIPTION
## Human comments

## What was wrong

Sidebar footer shortcuts had a fixed order and could not be hidden without losing access to an action or changing the plugin. Users need one customization surface for Settings, Report a bug, and registered plugin actions/disclosures.

## What changed

Settings → Appearance now supports footer drag ordering and visibility. Right-click Hide moves an action into More; More only appears when hidden registered actions exist and links back to Appearance. Hiding an open disclosure closes it, and More can reopen it with Escape focus restoration.

Stable IDs persist through the existing SDK/CLI UI preferences (`sidebar.footerOrder`, `sidebar.hiddenFooterItems`). Unknown/disabled-plugin preferences survive reloads; new actions default visible. Updated configuration docs, CLI guide/skill reference, and Plugin Guide. Uses the shared mobile drawer and guards non-left pointer release in the context menu. No daemon wire or plugin API changes.

Standalone adaptation of reference commit 2114294781 onto main at 001818f465; no unrelated provider usage/RPC changes.

## How you verified

- Turbo app/domain/server/plugin-api-map typechecks passed.
- 105 distinct targeted tests passed: footer behavior, preference synchronization/stored ordering, sidebar behavior, responsive drawer, and public UI-preference persistence/validation against a migrated database.
- Optimized isolated `pnpm start:worktree` preview: actual right-click Hide, hidden action/disclosure activation, Escape focus restoration, Appearance restoration, mouse drag and reload, CLI plugin disable/enable/reload, unknown IDs, all-hidden keyboard navigation.
- Chromium mobile touch: More drawer opens/closes/reopens, hidden disclosure works, Customize navigates, content stays mounted, app root is non-inert and not aria-hidden.
- iOS Safari interaction blocked: Computer Use returned `cgWindowNotFound` for Simulator. Desktop Chromium emitted a focus/aria-hidden warning during menu transitions; observed focus and mobile root checks passed. Full test suite not run.

[Remote isolated preview](https://ymichael-latest--26501.getbb.app) (owner Connect session required). Settings/Remote access visible; Provider usage/Report a bug in More. Unknown preference ID retained. Server is left running on 26501.

> AGENT GENERATED
