### PR TITLE
Approve leopoldsedev for pull requests [skip ci]

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -70,3 +70,4 @@ vznh
 MacHatter1
 noih
 nqrwhal
+leopoldsedev


### PR DESCRIPTION
## Human comments

## What was wrong

leopoldsedev was absent from the contributor allow list, so the PR gate would close their pull requests.

## What changed

Added leopoldsedev to `.github/APPROVED_CONTRIBUTORS`.

## How you verified

Confirmed the GitHub account exists and checked the PR gate matching logic. `git diff --check` passed. Pre-push scan passed with no EAP codename mentions. CI and SlopCop review skipped at the user's request.

> AGENT GENERATED
