### PR TITLE
Clarify Automations labels and rebuild component stories

### DIFF
--- a/apps/app/.ladle/model-picker-query-provider.tsx
+++ b/apps/app/.ladle/model-picker-query-provider.tsx
@@ -1,4 +1,5 @@
 import { useMemo, type ReactNode } from "react";
+import { makeSystemConfig } from "../src/test/fixtures/system-config";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type {
   AvailableModel,
@@ -7,7 +8,11 @@ import type {
   ReasoningLevel,
 } from "@bb/domain";
 import type { SystemExecutionOptionsResponse } from "@bb/server-contract";
-import { systemExecutionOptionsQueryKey } from "../src/hooks/queries/query-keys";
+import {
+  hostsQueryKey,
+  systemConfigQueryKey,
+  systemExecutionOptionsQueryKey,
+} from "../src/hooks/queries/query-keys";
 import type { PickerOption } from "../src/components/pickers/OptionPicker";
 import type { ModelPickerOption } from "../src/components/pickers/model-picker-option";
 import {
@@ -127,7 +132,7 @@ function makeExecutionOptions(
   };
 }
 
-function createStoryQueryClient(): QueryClient {
+function createStoryQueryClient(environmentId: string | null): QueryClient {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -172,7 +177,7 @@ function createStoryQueryClient(): QueryClient {
   )) {
     queryClient.setQueryData<SystemExecutionOptionsResponse>(
       systemExecutionOptionsQueryKey({
-        environmentId: null,
+        environmentId,
         hostId: null,
         providerId,
       }),
@@ -180,15 +185,23 @@ function createStoryQueryClient(): QueryClient {
     );
   }
 
+  queryClient.setQueryData(hostsQueryKey(), []);
+  queryClient.setQueryData(systemConfigQueryKey(), makeSystemConfig());
+
   return queryClient;
 }
 
 export function ModelPickerStoryQueryProvider({
   children,
+  environmentId = null,
 }: {
   children: ReactNode;
+  environmentId?: string | null;
 }) {
-  const queryClient = useMemo(createStoryQueryClient, []);
+  const queryClient = useMemo(
+    () => createStoryQueryClient(environmentId),
+    [environmentId],
+  );
 
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/apps/app/.ladle/plugin-sdk-app.ts
+++ b/apps/app/.ladle/plugin-sdk-app.ts
@@ -1,0 +1,37 @@
+import { pluginSdkAppImplementation } from "../src/lib/plugin-sdk-app-impl";
+
+export type * from "@get-bb/plugin-sdk";
+
+export const {
+  experimental_Icon,
+  experimental_ProviderIcon,
+  definePluginApp,
+  ThreadChat,
+  Markdown,
+  experimental_FileLink,
+  UrlLink,
+  experimental_NewThreadComposer,
+  experimental_ProviderModelPicker,
+  experimental_PermissionModePicker,
+  experimental_BranchPicker,
+  experimental_useBranches,
+  experimental_useCheckoutState,
+  experimental_SourceCode,
+  experimental_Diff,
+  useRpc,
+  useRealtime,
+  useRealtimeConnectionState,
+  useSettings,
+  useBbContext,
+  useBbNavigate,
+  experimental_useAppPanel,
+  experimental_useFixedTabTarget,
+  useComposer,
+  useComposerView,
+  experimental_useSidebarThreads,
+  experimental_useSidebarThreadActions,
+  experimental_useSidebarThreadPullRequest,
+  experimental_useSidebarThreadSplit,
+  experimental_useProviders,
+  experimental_useCodeTheme,
+} = pluginSdkAppImplementation;

--- a/apps/app/.ladle/vite.config.ts
+++ b/apps/app/.ladle/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     conditions: ["source"],
     dedupe: ["react", "react-dom"],
     alias: {
+      "@get-bb/plugin-sdk/app": path.resolve(__dirname, "./plugin-sdk-app.ts"),
       "@": path.resolve(__dirname, "../src"),
     },
   },

--- a/apps/app/src/components/tools/Automations.stories.tsx
+++ b/apps/app/src/components/tools/Automations.stories.tsx
@@ -1,19 +1,22 @@
-import { useState, type CSSProperties, type ReactNode } from "react";
-import { AutomationDetailView } from "bb-plugin-automations/detail-view";
+import { useState } from "react";
 import {
-  AutomationOverviewView,
-  type AutomationCollectionMode,
-} from "bb-plugin-automations/overview-view";
+  AgentAutomationDefinition,
+  AutomationScriptContent,
+  ScriptAutomationDefinition,
+  RunRow,
+} from "bb-plugin-automations/detail-view";
+import { OverviewRow } from "bb-plugin-automations/overview-view";
 import type {
   AutomationResponse,
+  AgentEnvironment,
   AutomationRunResponse,
   AutomationsOverviewResponse,
 } from "bb-plugin-automations/rpc-types";
 import { ResourceListState } from "@bb/shared-ui/resource-list";
+import { StoryCard, StoryRow } from "../../../.ladle/story-card";
+import { ModelPickerStoryQueryProvider } from "../../../.ladle/model-picker-query-provider";
 
-export default {
-  title: "Automations",
-};
+export default { title: "Automations" };
 
 const noop = () => {};
 const now = new Date(2027, 0, 15, 9).getTime();
@@ -36,8 +39,8 @@ function automation(
     execution: {
       mode: "agent",
       prompt: `Run ${name.toLowerCase()}.`,
-      providerId: "claude",
-      model: "claude-opus-5",
+      providerId: "claude-code",
+      model: "claude-fable-5",
       reasoningLevel: "medium",
       permissionMode: "auto",
       environment: { type: "host", workspace: { type: "personal" } },
@@ -106,76 +109,6 @@ const OVERVIEW_ENTRIES: AutomationsOverviewResponse["automations"] = [
   },
 ];
 
-function StoryFrame({ children }: { children: ReactNode }) {
-  return (
-    <main className="mx-auto box-border h-[720px] w-full max-w-5xl px-5 py-4">
-      {children}
-    </main>
-  );
-}
-
-function Overview({
-  entries = OVERVIEW_ENTRIES,
-  error = null,
-  initialMode = "installed",
-}: {
-  entries?: AutomationsOverviewResponse["automations"] | null;
-  error?: string | null;
-  initialMode?: AutomationCollectionMode;
-}) {
-  const [mode, setMode] = useState<AutomationCollectionMode>(initialMode);
-  return (
-    <StoryFrame>
-      <AutomationOverviewView
-        entries={entries}
-        error={error}
-        onRetry={noop}
-        onOpenDetail={noop}
-        onEnabledChange={async () => {}}
-        onCreateViaChat={noop}
-        activeMode={mode}
-        onModeChange={setMode}
-      />
-    </StoryFrame>
-  );
-}
-
-export function OverviewPage() {
-  return <Overview />;
-}
-
-export function OverviewStates() {
-  return (
-    <main className="mx-auto w-full max-w-5xl space-y-8 px-5 py-6">
-      {[
-        {
-          label: "Loading",
-          content: <Overview entries={null} />,
-        },
-        {
-          label: "Empty",
-          content: <Overview entries={[]} />,
-        },
-        {
-          label: "Failed",
-          content: <Overview entries={null} error="Connection timed out" />,
-        },
-      ].map(({ label, content }) => (
-        <section key={label} className="space-y-2">
-          <h2 className="text-sm font-medium text-foreground">{label}</h2>
-          <div className="overflow-hidden rounded-md border border-border">
-            {content}
-          </div>
-        </section>
-      ))}
-    </main>
-  );
-}
-
-export function BrowseTemplates() {
-  return <Overview initialMode="browse" />;
-}
-
 const DETAIL_AUTOMATION = automation("nightly-digest", "Nightly digest", {
   trigger: {
     triggerType: "schedule",
@@ -185,8 +118,8 @@ const DETAIL_AUTOMATION = automation("nightly-digest", "Nightly digest", {
   execution: {
     mode: "agent",
     prompt: "Summarize yesterday's commits and open pull requests.",
-    providerId: "claude",
-    model: "claude-opus-5[1m]",
+    providerId: "claude-code",
+    model: "claude-fable-5",
     reasoningLevel: "medium",
     permissionMode: "auto",
     environment: { type: "host", workspace: { type: "personal" } },
@@ -206,13 +139,13 @@ const PROJECT_AUTOMATION: AutomationResponse = {
   execution: {
     mode: "agent",
     prompt: "Summarize yesterday's commits and open pull requests.",
-    providerId: "claude",
-    model: "claude-opus-5[1m]",
+    providerId: "claude-code",
+    model: "claude-fable-5",
     reasoningLevel: "medium",
     permissionMode: "auto",
     environment: {
       type: "host",
-      hostId: "host_local",
+
       workspace: {
         type: "unmanaged",
         path: "/Users/you/Code/bb",
@@ -221,69 +154,6 @@ const PROJECT_AUTOMATION: AutomationResponse = {
     },
   },
 };
-
-const PROVIDER_AUTOMATIONS = [
-  {
-    label: "Claude",
-    value: PROJECT_AUTOMATION,
-  },
-  {
-    label: "Codex",
-    value: automation("codex-digest", "Codex digest", {
-      execution: {
-        mode: "agent",
-        prompt: "Summarize yesterday's commits and open pull requests.",
-        providerId: "codex",
-        model: "gpt-5.6-sol",
-        reasoningLevel: "medium",
-        permissionMode: "auto",
-        environment: { type: "host", workspace: { type: "personal" } },
-      },
-    }),
-  },
-  {
-    label: "Pi",
-    value: automation("pi-digest", "Pi digest", {
-      execution: {
-        mode: "agent",
-        prompt: "Summarize yesterday's commits and open pull requests.",
-        providerId: "pi",
-        model: "pi-model",
-        reasoningLevel: "medium",
-        permissionMode: "auto",
-        environment: { type: "host", workspace: { type: "personal" } },
-      },
-    }),
-  },
-  {
-    label: "Cursor",
-    value: automation("cursor-digest", "Cursor digest", {
-      execution: {
-        mode: "agent",
-        prompt: "Summarize yesterday's commits and open pull requests.",
-        providerId: "acp-cursor",
-        model: "cursor-small",
-        reasoningLevel: "medium",
-        permissionMode: "auto",
-        environment: { type: "host", workspace: { type: "personal" } },
-      },
-    }),
-  },
-  {
-    label: "Unknown provider",
-    value: automation("custom-digest", "Custom-provider digest", {
-      execution: {
-        mode: "agent",
-        prompt: "Summarize yesterday's commits and open pull requests.",
-        providerId: "custom-provider",
-        model: "custom-model-v2",
-        reasoningLevel: "medium",
-        permissionMode: "auto",
-        environment: { type: "host", workspace: { type: "personal" } },
-      },
-    }),
-  },
-] as const;
 
 const SCRIPT_AUTOMATION: AutomationResponse = {
   ...DETAIL_AUTOMATION,
@@ -333,28 +203,6 @@ echo "Reports written to $output_dir"`,
   },
 };
 
-const UNSCHEDULED_AUTOMATION: AutomationResponse = {
-  ...DETAIL_AUTOMATION,
-  id: "unscheduled-digest",
-  name: "Unscheduled digest",
-  nextRunAt: null,
-  lastRunAt: now - 3_600_000,
-  runCount: 1,
-  lastRunStatus: "succeeded",
-};
-
-const COMPLETED_AUTOMATION: AutomationResponse = {
-  ...DETAIL_AUTOMATION,
-  id: "one-time-backfill",
-  name: "One-time backfill",
-  trigger: { triggerType: "once", runAt: now - 86_400_000 },
-  enabled: false,
-  nextRunAt: null,
-  runCount: 1,
-  lastRunAt: now - 86_400_000,
-  lastRunStatus: "succeeded",
-};
-
 function runsFor(
   value: AutomationResponse,
   statuses: readonly AutomationRunResponse["status"][],
@@ -395,218 +243,347 @@ function runsFor(
   });
 }
 
-const PROJECT_RUNS = runsFor(PROJECT_AUTOMATION, [
-  "running",
-  "failed",
-  "succeeded",
-]);
-
-const PAUSED_AUTOMATION: AutomationResponse = {
-  ...DETAIL_AUTOMATION,
-  enabled: false,
-  lastRunAt: now - 3_600_000,
-  runCount: 2,
-  lastRunStatus: "failed",
-};
-
-function AutomationDetail({
-  value = DETAIL_AUTOMATION,
-  projectLabel = "Local",
-  runs = [],
-  loading = false,
-  error = null,
+function PromptVariant({
+  value,
+  editable = false,
+  projectLabel,
 }: {
-  value?: AutomationResponse;
+  value: AutomationResponse;
+  editable?: boolean;
   projectLabel?: string;
-  runs?: readonly AutomationRunResponse[];
-  loading?: boolean;
-  error?: string | null;
 }) {
+  const [execution, setExecution] = useState(value.execution);
+  const [editing, setEditing] = useState(editable);
+  if (execution.mode !== "agent") return null;
   return (
-    <AutomationDetailView
-      automation={value}
-      projectLabel={projectLabel}
-      runsState={{
-        runs,
-        nextCursor: null,
-        loading,
-        loadingMore: false,
-        error,
-        loadMore: noop,
-        retry: noop,
-      }}
-      actionPending={false}
-      editing={false}
-      onToggle={noop}
-      onEdit={noop}
-      onCancelEdit={noop}
-      onUpdateAgent={async () => {}}
-      onRunNow={noop}
-      onDelete={noop}
-      onOpenThread={noop}
-    />
+    <ModelPickerStoryQueryProvider
+      environmentId={
+        execution.environment.type === "reuse"
+          ? execution.environment.environmentId
+          : null
+      }
+    >
+      <div className="w-full max-w-2xl">
+        <AgentAutomationDefinition
+          execution={execution}
+          editing={editing}
+          personalProject={value.projectId === "proj_personal"}
+          projectContextLabel={
+            projectLabel ??
+            (value.projectId === "proj_personal" ? "Personal" : "bb")
+          }
+          pending={false}
+          onCancel={() => setEditing(false)}
+          onUpdate={async (update) => {
+            setExecution({
+              ...execution,
+              ...update,
+              serviceTier: update.serviceTier ?? undefined,
+            });
+            setEditing(false);
+          }}
+        />
+      </div>
+    </ModelPickerStoryQueryProvider>
   );
 }
 
-function DetailState({
-  name,
-  note,
-  children,
-}: {
-  name: string;
-  note: string;
-  children: ReactNode;
-}) {
+export function OverviewRows() {
+  const descriptions: Record<string, { label: string; hint: string }> = {
+    "ci-triage": {
+      label: "Recurring · Personal",
+      hint: "Enabled weekday schedule in the Personal project. Shows the project label and next run.",
+    },
+    release: {
+      label: "Run in progress",
+      hint: "A recurring project automation whose latest run is still running. Shows the activity spinner.",
+    },
+    "pending-reminder": {
+      label: "One-time · pending",
+      hint: "Scheduled once for a future date. Shows One time and the next-run date.",
+    },
+    dependencies: {
+      label: "Paused",
+      hint: "Disabled recurring automation. The switch is off and there is no next-run date.",
+    },
+    "one-shot": {
+      label: "One-time · completed",
+      hint: "Already ran successfully. The row is muted and its switch cannot be enabled again.",
+    },
+    "stale-worktrees": {
+      label: "Last run failed",
+      hint: "The latest run failed, but the recurring schedule remains enabled. Shows the failure indicator.",
+    },
+  };
   return (
-    <section className="grid grid-cols-[var(--story-doc-width)_minmax(0,1fr)] items-start max-[900px]:grid-cols-1">
-      <div className="h-full border-r border-border bg-surface-recessed max-[900px]:border-b max-[900px]:border-r-0">
-        <div className="sticky top-0 px-4 py-4">
-          <h2 className="text-sm font-medium text-foreground">{name}</h2>
-          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-            {note}
-          </p>
+    <StoryCard>
+      {OVERVIEW_ENTRIES.map(({ automation: value, project }) => (
+        <StoryRow
+          key={value.id}
+          label={descriptions[value.id]?.label ?? value.name}
+          hint={descriptions[value.id]?.hint}
+        >
+          {"execution" in value ? (
+            <div className="w-full max-w-3xl">
+              <OverviewRow
+                automation={value}
+                project={project}
+                onNavigate={noop}
+                onEnabledChange={async () => {}}
+              />
+            </div>
+          ) : null}
+        </StoryRow>
+      ))}
+      <StoryRow
+        label="Script automation"
+        hint="Uses the script icon instead of the agent calendar icon. The schedule and toggle use the same row layout."
+      >
+        <div className="w-full max-w-3xl">
+          <OverviewRow
+            automation={SCRIPT_AUTOMATION}
+            project={{ id: "proj_personal", name: "Personal" }}
+            onNavigate={noop}
+            onEnabledChange={async () => {}}
+          />
         </div>
-      </div>
-      <div className="min-w-0 px-5 py-5">{children}</div>
-    </section>
+      </StoryRow>
+    </StoryCard>
   );
+}
+
+export function OverviewStates() {
+  const states = [
+    {
+      label: "Fetching automations",
+      hint: "Replaces the list while its first request is pending. The page reveals these four skeleton rows after its loading delay.",
+      state: "loading",
+      message: "Loading automations",
+    },
+    {
+      label: "No automations created",
+      hint: "The request succeeded, but there are no installed automations.",
+      state: "empty",
+      message: "No automations installed.",
+    },
+    {
+      label: "Could not load the list",
+      hint: "The request failed. The page offers Retry; this isolated example does not make a request.",
+      state: "error",
+      message: "Couldn't load automations.",
+    },
+    {
+      label: "No search results",
+      hint: "Automations exist, but none match the entered search text.",
+      state: "empty",
+      message: 'No automations match "release"',
+    },
+    {
+      label: "No filter matches",
+      hint: "Automations exist, but the selected project or status filters exclude all of them.",
+      state: "empty",
+      message: "No automations match these filters.",
+    },
+    {
+      label: "No search and filter matches",
+      hint: "Both a search term and filters are active, and no automation matches both.",
+      state: "empty",
+      message: 'No automations match "release" with these filters.',
+    },
+  ] as const;
+  return (
+    <StoryCard>
+      {states.map(({ label, hint, state, message }) => (
+        <StoryRow key={label} label={label} hint={hint}>
+          <div className="w-full max-w-3xl">
+            <ResourceListState
+              state={state}
+              message={message}
+              onRetry={state === "error" ? noop : undefined}
+            />
+          </div>
+        </StoryRow>
+      ))}
+    </StoryCard>
+  );
+}
+
+function environmentVariant(
+  environment: AgentEnvironment,
+  targetThreadId?: string,
+): AutomationResponse {
+  const value = PROJECT_AUTOMATION;
+  if (value.execution.mode !== "agent") return value;
+  return {
+    ...value,
+    execution: {
+      ...value.execution,
+      environment,
+      ...(targetThreadId === undefined ? {} : { targetThreadId }),
+    },
+  };
 }
 
 export function DetailStates() {
   return (
-    <main
-      className="mx-auto w-full max-w-[72rem] space-y-4 px-5 py-6"
-      style={{ "--story-doc-width": "232px" } as CSSProperties}
-    >
-      <header>
-        <h1 className="text-lg font-semibold text-foreground">
-          Automation detail states
-        </h1>
-        <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-          An automation page is Definition then Runs. Runs owns its loading,
-          empty, failed, and populated states without moving.
-        </p>
-      </header>
-      <div className="divide-y divide-border overflow-hidden rounded-md border border-border bg-card">
-        <DetailState
-          name="Agent automation"
-          note="A recurring prompt with disabled model and access selectors plus its exact configured project location."
-        >
-          <AutomationDetail
-            value={PROJECT_AUTOMATION}
-            projectLabel="bb"
-            runs={PROJECT_RUNS}
+    <StoryCard>
+      <StoryRow
+        label="Personal workspace prompt"
+        hint="Read-only prompt using a personal workspace. The footer shows its configured workspace and permissions."
+      >
+        <PromptVariant value={DETAIL_AUTOMATION} />
+      </StoryRow>
+      <StoryRow
+        label="Project checkout prompt"
+        hint="Read-only prompt in a project. The footer includes the project name and configured checkout path."
+      >
+        <PromptVariant value={PROJECT_AUTOMATION} />
+      </StoryRow>
+      <StoryRow
+        label="Reuse an environment"
+        hint="An existing environment ID is configured. Shows Reuse environment with the same open-folder icon as core’s reuse selector."
+      >
+        <PromptVariant
+          value={environmentVariant({
+            type: "reuse",
+            environmentId: "env_story_reuse",
+          })}
+        />
+      </StoryRow>
+      <StoryRow
+        label="Create a new worktree"
+        hint="Creates a managed worktree from the default branch. Shows New worktree metadata."
+      >
+        <PromptVariant
+          value={environmentVariant({
+            type: "host",
+            workspace: {
+              type: "managed-worktree",
+              baseBranch: { kind: "default" },
+            },
+          })}
+        />
+      </StoryRow>
+      <StoryRow
+        label="Use project defaults"
+        hint="No explicit workspace is configured. Shows Project default metadata."
+      >
+        <PromptVariant
+          value={environmentVariant({ type: "project-default" })}
+        />
+      </StoryRow>
+      <StoryRow
+        label="Send to an existing thread"
+        hint="The target thread takes precedence over the fallback environment. Shows Existing thread metadata."
+      >
+        <PromptVariant
+          value={environmentVariant(
+            { type: "project-default" },
+            "thr_story_existing",
+          )}
+        />
+      </StoryRow>
+      <StoryRow
+        label="Checkout without a path"
+        hint="An unmanaged workspace with no configured path. Shows the Workspace fallback label."
+      >
+        <PromptVariant
+          value={environmentVariant({
+            type: "host",
+            workspace: { type: "unmanaged", path: null },
+          })}
+        />
+      </StoryRow>
+      <StoryRow
+        label="Long project and path"
+        hint="Exercises truncation when both the project name and checkout path are long."
+      >
+        <PromptVariant
+          projectLabel="Infrastructure and release engineering"
+          value={environmentVariant({
+            type: "host",
+            workspace: {
+              type: "unmanaged",
+              path: "/Users/you/Code/infrastructure-and-release-engineering/services/deployment-orchestrator",
+            },
+          })}
+        />
+      </StoryRow>
+      <StoryRow
+        label="Narrow prompt box"
+        hint="A 320px-wide reused-environment prompt. Exercises compact labels and permission-control sizing."
+      >
+        <div className="w-80 max-w-full">
+          <PromptVariant
+            value={environmentVariant({
+              type: "reuse",
+              environmentId: "env_story_reuse",
+            })}
           />
-        </DetailState>
-        <DetailState
-          name="Script automation"
-          note="The exact stored script that will run, capped with a bottom fade and transient scrollbar. Environment-variable names are available without exposing values."
-        >
-          <AutomationDetail
-            value={SCRIPT_AUTOMATION}
-            runs={runsFor(SCRIPT_AUTOMATION, ["succeeded"])}
+        </div>
+      </StoryRow>
+      <StoryRow
+        label="editing prompt"
+        hint="Change the prompt, model, or permission; Save and Cancel update this example."
+      >
+        <PromptVariant value={PROJECT_AUTOMATION} editable />
+      </StoryRow>
+      <StoryRow
+        label="Short script"
+        hint="A script that fits without scrolling or a bottom fade."
+      >
+        <div className="w-full max-w-2xl rounded-md border border-border">
+          <AutomationScriptContent content={'echo "Reports ready"'} />
+        </div>
+      </StoryRow>
+      <StoryRow
+        label="Script environment variables"
+        hint="A script with two configured variables. Their count sits beside the interpreter and timeout; hover or focus it to see the names."
+      >
+        <div className="w-full max-w-2xl">
+          <ScriptAutomationDefinition
+            execution={{
+              mode: "script",
+              script: 'echo "Preparing report"',
+              interpreter: "bash",
+              timeoutMs: 60000,
+              env: {
+                REPORT_OUTPUT: "/tmp/story-reports",
+                API_TOKEN: "story-only-value",
+              },
+            }}
           />
-        </DetailState>
-        <DetailState
-          name="No next run"
-          note="Enabled and recurring, but nothing is scheduled. The upcoming-run slot says so rather than going blank."
-        >
-          <AutomationDetail
-            value={UNSCHEDULED_AUTOMATION}
-            runs={runsFor(UNSCHEDULED_AUTOMATION, ["succeeded"])}
+        </div>
+      </StoryRow>
+      <StoryRow label="long script" hint="Scroll within the script preview.">
+        <div className="w-full max-w-2xl rounded-md border border-border">
+          <AutomationScriptContent
+            content={
+              SCRIPT_AUTOMATION.execution.mode === "script"
+                ? (SCRIPT_AUTOMATION.execution.script ?? "")
+                : ""
+            }
           />
-        </DetailState>
-        <DetailState
-          name="Completed one-time run"
-          note="A one-shot that already ran. The trigger still says One time and the run itself is in Runs, so the meta row no longer repeats “Completed”."
-        >
-          <AutomationDetail
-            value={COMPLETED_AUTOMATION}
-            runs={runsFor(COMPLETED_AUTOMATION, ["succeeded"])}
-          />
-        </DetailState>
-        <DetailState
-          name="No runs yet"
-          note="The Runs section stays in place and explains itself rather than collapsing."
-        >
-          <AutomationDetail />
-        </DetailState>
-        <DetailState
-          name="Runs loading"
-          note="The definition is usable while history is still arriving."
-        >
-          <AutomationDetail loading />
-        </DetailState>
-        <DetailState
-          name="Runs unavailable"
-          note="Only the run history is unavailable; the definition remains usable, and Retry stays with the affected section."
-        >
-          <AutomationDetail error="Request timed out" />
-        </DetailState>
-        <DetailState
-          name="Paused"
-          note="A disabled automation keeps its full definition and history."
-        >
-          <AutomationDetail
-            value={PAUSED_AUTOMATION}
-            runs={runsFor(PAUSED_AUTOMATION, ["failed", "succeeded"])}
-          />
-        </DetailState>
-        <DetailState
-          name="Route loading"
-          note="Before the automation resolves."
-        >
-          <ResourceListState
-            state="loading"
-            message="Loading automation"
-            layout="detail"
-          />
-        </DetailState>
-        <DetailState
-          name="Route not found"
-          note="The automation was deleted or the id is wrong."
-        >
-          <ResourceListState
-            state="error"
-            message="Automation not found."
-            layout="detail"
-            onRetry={noop}
-          />
-        </DetailState>
-      </div>
-    </main>
+        </div>
+      </StoryRow>
+    </StoryCard>
   );
 }
 
-export function ProviderIdentities() {
+export function RunStates() {
   return (
-    <main
-      className="mx-auto w-full max-w-[72rem] space-y-4 px-5 py-6"
-      style={{ "--story-doc-width": "160px" } as CSSProperties}
-    >
-      <header>
-        <h1 className="text-lg font-semibold text-foreground">
-          Automation provider identities
-        </h1>
-        <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-          Saved prompt metadata uses the configured provider identity and keeps
-          model context visible.
-        </p>
-      </header>
-      <div className="divide-y divide-border overflow-hidden rounded-md border border-border bg-card">
-        {PROVIDER_AUTOMATIONS.map(({ label, value }) => (
-          <DetailState
-            key={value.id}
-            name={label}
-            note="Production read-only automation detail."
-          >
-            <AutomationDetail
-              value={value}
-              projectLabel={value.projectId === "proj_bb" ? "bb" : "Local"}
-            />
-          </DetailState>
-        ))}
-      </div>
-    </main>
+    <StoryCard>
+      {[PROJECT_AUTOMATION, SCRIPT_AUTOMATION].flatMap((value) =>
+        runsFor(value, ["running", "succeeded", "failed", "skipped"]).map(
+          (run) => (
+            <StoryRow key={run.id} label={`${run.runMode} · ${run.status}`}>
+              <div className="w-full max-w-2xl">
+                <RunRow run={run} onOpenThread={noop} />
+              </div>
+            </StoryRow>
+          ),
+        ),
+      )}
+    </StoryCard>
   );
 }

--- a/apps/app/src/components/tools/automation-overview.test.tsx
+++ b/apps/app/src/components/tools/automation-overview.test.tsx
@@ -526,6 +526,38 @@ describe("AutomationOverviewView", () => {
     expect((await screen.findByRole("tooltip")).textContent).toBe("Next run");
   });
 
+  it("shows Personal as project membership and keeps it searchable", async () => {
+    render(
+      <AutomationOverviewView
+        entries={[
+          {
+            ...INSTALLED_AUTOMATIONS[0]!,
+            project: { id: "proj_personal", name: "Personal" },
+          },
+        ]}
+        error={null}
+        onRetry={() => {}}
+        onOpenDetail={() => {}}
+        onEnabledChange={async () => {}}
+        onCreateViaChat={() => {}}
+        activeMode="installed"
+        onModeChange={() => {}}
+      />,
+    );
+    const icon = screen.getByRole("img", { name: "Project: Personal" });
+    expect(icon.querySelector('[data-icon="Folder"]')).not.toBeNull();
+    expect(screen.queryByText("Local")).toBeNull();
+    expect(screen.getByText("Personal")).toBeTruthy();
+    fireEvent.change(screen.getByPlaceholderText("Search automations"), {
+      target: { value: "Personal" },
+    });
+    expect(screen.getByText("Nightly digest")).toBeTruthy();
+    focusWithKeyboard(icon);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Project: Personal",
+    );
+  });
+
   it("does not treat a project named Local as the personal project", () => {
     const namedLocalEntry = {
       ...INSTALLED_AUTOMATIONS[0]!,

--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -22,11 +22,14 @@ import type {
 } from "@get-bb/plugin-sdk/app";
 import {
   AutomationDetailView as AutomationDetailViewBase,
+  AgentAutomationDefinition,
   AutomationRunStatusIndicator,
 } from "bb-plugin-automations/detail-view";
 
 vi.mock("@get-bb/plugin-sdk/app", async (importOriginal) => ({
   ...(await importOriginal()),
+  experimental_ProviderIcon: (await import("@/components/plugin/ProviderIcon"))
+    .ProviderIcon,
   experimental_ProviderModelPicker: ({
     value,
     onChange,
@@ -804,6 +807,49 @@ function AutomationDetailView({
 }
 
 describe("Automation detail recipe", () => {
+  it("uses the host environment provider renderer and responds to icon overrides", () => {
+    const { container } = render(
+      <AgentAutomationDefinition
+        execution={{
+          mode: "agent",
+          prompt: "Check",
+          providerId: "codex",
+          model: "test",
+          reasoningLevel: "medium",
+          permissionMode: "auto",
+          environment: { type: "host", workspace: { type: "personal" } },
+        }}
+        editing={false}
+        personalProject
+        projectContextLabel="Personal"
+        pending={false}
+        onCancel={() => {}}
+        onUpdate={async () => {}}
+      />,
+    );
+    const footer = container.querySelector("[data-automation-prompt-footer]")!;
+    expect(footer.querySelector('[data-icon="Folder"]')).not.toBeNull();
+    act(() =>
+      setPluginSlotRegistrations(
+        "test-environment-icons",
+        makePluginRegistrationSet({
+          providerIcons: [
+            {
+              providerKind: "environment",
+              providerId: "personal-workspace",
+              icon: () => <svg data-test-environment-mark="" />,
+            },
+          ],
+        }),
+      ),
+    );
+    expect(footer.querySelector("[data-test-environment-mark]")).not.toBeNull();
+    expect(footer.querySelector('[data-icon="Folder"]')).toBeNull();
+    act(() => resetPluginSlotStoreForTest());
+    expect(footer.querySelector("[data-test-environment-mark]")).toBeNull();
+    expect(footer.querySelector('[data-icon="Folder"]')).not.toBeNull();
+  });
+
   it("keeps Definition ahead of Runs, including with no runs yet", async () => {
     const updateAgent = vi.fn(async (_update: AgentExecutionUpdate) => {});
     function Harness() {
@@ -811,7 +857,7 @@ describe("Automation detail recipe", () => {
       return (
         <AutomationDetailView
           automation={AUTOMATION}
-          projectLabel="Local"
+          projectLabel="Personal"
           runsState={{
             runs: [],
             nextCursor: null,
@@ -846,7 +892,7 @@ describe("Automation detail recipe", () => {
     expect(recipe.map(([kind]) => kind)).toEqual(["definition", "activity"]);
     expect(recipe.at(-1)?.[1]).toBe("Runs");
     const projectMetadataIcon = screen.getByRole("img", {
-      name: "Local project",
+      name: "Project: Personal",
     });
     const scheduleMetadataIcon = screen.getByRole("img", {
       name: "Schedule",
@@ -858,7 +904,7 @@ describe("Automation detail recipe", () => {
     expect(scheduleMetadataIcon.tabIndex).toBe(0);
     expect(nextRunMetadataIcon.tabIndex).toBe(0);
     expect(
-      projectMetadataIcon.querySelector('[data-icon="Laptop"]'),
+      projectMetadataIcon.querySelector('[data-icon="Folder"]'),
     ).toBeTruthy();
     expect(
       scheduleMetadataIcon.querySelector('[data-icon="DateTime"]'),
@@ -921,7 +967,10 @@ describe("Automation detail recipe", () => {
     const promptFooter = container.querySelector(
       '[data-automation-prompt-footer=""]',
     ) as HTMLElement;
-    expect(promptFooter.textContent).toContain("Local");
+    expect(promptFooter.textContent).toContain("Personal workspace");
+    expect(
+      promptFooter.querySelector('[title="Environment: Personal workspace"]'),
+    ).not.toBeNull();
     expect(promptFooter.textContent).toContain("Approve for me");
     expect(
       promptFooter.querySelectorAll('[data-option-display=""]'),
@@ -1139,7 +1188,7 @@ describe("Automation detail recipe", () => {
               },
             },
           }}
-          projectLabel="Local"
+          projectLabel="Personal"
           runsState={{
             runs: [],
             nextCursor: null,
@@ -1206,7 +1255,7 @@ describe("Automation detail recipe", () => {
       <MemoryRouter>
         <AutomationDetailView
           automation={AUTOMATION}
-          projectLabel="Local"
+          projectLabel="Personal"
           runsState={{
             runs: [],
             nextCursor: null,
@@ -1239,7 +1288,7 @@ describe("Automation detail recipe", () => {
       <MemoryRouter>
         <AutomationDetailView
           automation={AUTOMATION}
-          projectLabel="Local"
+          projectLabel="Personal"
           runsState={{
             runs: [],
             nextCursor: null,

--- a/plugins/automations/app.tsx
+++ b/plugins/automations/app.tsx
@@ -614,7 +614,7 @@ function DetailView({
     overviewEntry !== undefined
       ? automationProjectLabel(overviewEntry.project)
       : route.projectId === PERSONAL_PROJECT_ID
-        ? "Local"
+        ? "Personal"
         : route.projectId;
 
   return (

--- a/plugins/automations/detail-view.tsx
+++ b/plugins/automations/detail-view.tsx
@@ -10,6 +10,7 @@ import type {
 } from "./src/rpc-types";
 import {
   experimental_PermissionModePicker as PermissionModePicker,
+  experimental_ProviderIcon as ProviderIcon,
   experimental_ProviderModelPicker as ProviderModelPicker,
   type ExperimentalProviderModelPickerRouting,
   type ExperimentalProviderModelPickerValue,
@@ -181,7 +182,7 @@ function automationBodyLabel(execution: AutomationExecution): string {
 
 const SCRIPT_SCROLLBAR_IDLE_DELAY_MS = 600;
 
-function AutomationScriptContent({ content }: { content: string }) {
+export function AutomationScriptContent({ content }: { content: string }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const scrollbarIdleTimeoutRef = useRef<number | null>(null);
   const [hasMoreBelow, setHasMoreBelow] = useState(false);
@@ -287,10 +288,10 @@ function AutomationEnvironmentVariables({
 function automationEnvironmentLabel(execution: AutomationExecution): string {
   if (execution.mode !== "agent") return "Host";
   const environment = execution.environment;
-  if (environment.type === "reuse") return "Reuse worktree";
+  if (environment.type === "reuse") return "Reuse environment";
   if (environment.type === "project-default") return "Project default";
   if (environment.workspace.type === "managed-worktree") return "New worktree";
-  if (environment.workspace.type === "personal") return "Local";
+  if (environment.workspace.type === "personal") return "Personal workspace";
   return environment.workspace.path == null
     ? "Workspace"
     : formatHomePathForDisplay(environment.workspace.path);
@@ -301,35 +302,45 @@ function automationEnvironmentCompactLabel(
 ): string {
   if (execution.targetThreadId !== undefined) return "Thread";
   const environment = execution.environment;
-  if (environment.type === "reuse") return "Reuse";
+  if (environment.type === "reuse") return "Reuse environment";
   if (environment.type === "project-default") return "Default";
   if (environment.workspace.type === "managed-worktree") return "Worktree";
-  if (environment.workspace.type === "personal") return "Local";
+  if (environment.workspace.type === "personal") return "Personal workspace";
   return environment.workspace.path === null
     ? "Workspace"
     : formatHomePathForDisplay(environment.workspace.path);
 }
 
-function automationEnvironmentIcon(
-  execution: Extract<AutomationExecution, { mode: "agent" }>,
-): IconName {
-  if (execution.targetThreadId !== undefined) return "MessageSquare";
+function AutomationEnvironmentIcon({
+  execution,
+}: {
+  execution: Extract<AutomationExecution, { mode: "agent" }>;
+}) {
+  const className = "size-3.5 shrink-0";
+  if (execution.targetThreadId !== undefined) {
+    return <Icon name="MessageSquare" className={className} aria-hidden />;
+  }
   const environment = execution.environment;
-  if (
-    environment.type === "reuse" ||
-    (environment.type === "host" &&
-      environment.workspace.type === "managed-worktree")
-  ) {
-    return "FolderGit";
+  if (environment.type === "reuse") {
+    return <Icon name="Folder02" className={className} aria-hidden />;
   }
-  if (
-    environment.type === "host" &&
-    (environment.workspace.type === "personal" ||
-      environment.workspace.type === "unmanaged")
-  ) {
-    return "Laptop";
+  if (environment.type === "project-default") {
+    return <Icon name="Folder" className={className} aria-hidden />;
   }
-  return "Folder";
+  const providers = {
+    personal: { id: "personal-workspace", fallback: "Folder" },
+    "managed-worktree": { id: "git-worktree", fallback: "FolderGit" },
+    unmanaged: { id: "project-checkout", fallback: "Laptop" },
+  } as const;
+  const provider = providers[environment.workspace.type];
+  return (
+    <ProviderIcon
+      providerKind="environment"
+      provider={{ id: provider.id }}
+      fallback={provider.fallback}
+      className={className}
+    />
+  );
 }
 
 function formatRunDuration(run: AutomationRunResponse): string | null {
@@ -401,7 +412,7 @@ export function AutomationRunStatusIndicator({
   );
 }
 
-function RunRow({
+export function RunRow({
   run,
   onOpenThread,
 }: {
@@ -499,7 +510,7 @@ function RunRow({
   );
 }
 
-function AgentAutomationDefinition({
+export function AgentAutomationDefinition({
   execution,
   editing,
   personalProject,
@@ -570,13 +581,7 @@ function AgentAutomationDefinition({
               : automationEnvironmentLabel(execution)
           }
           compactValue={automationEnvironmentCompactLabel(execution)}
-          leading={
-            <Icon
-              name={automationEnvironmentIcon(execution)}
-              className="size-3.5 shrink-0"
-              aria-hidden
-            />
-          }
+          leading={<AutomationEnvironmentIcon execution={execution} />}
           muted
         />
       </div>
@@ -702,6 +707,40 @@ function AgentAutomationDefinition({
   );
 }
 
+export function ScriptAutomationDefinition({
+  execution,
+}: {
+  execution: Extract<AutomationExecution, { mode: "script" }>;
+}) {
+  return (
+    <ResourceDetailPanel
+      surface="flat"
+      className="rounded-md border border-border bg-background"
+    >
+      {execution.script ? (
+        <AutomationScriptContent content={execution.script} />
+      ) : (
+        <div className="px-3 py-3 text-xs text-muted-foreground">
+          Script content unavailable.
+        </div>
+      )}
+      <div className="flex min-w-0 flex-wrap items-center gap-x-4 gap-y-1.5 border-t border-border bg-surface-recessed/55 px-3 py-2 text-xs text-muted-foreground">
+        <span className="inline-flex items-center gap-1.5">
+          <Icon name="ComputerTerminal01" className="size-3.5" aria-hidden />
+          {execution.interpreter ?? "bash"}
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <Icon name="Clock" className="size-3.5" aria-hidden />
+          {Math.round(execution.timeoutMs / 1000)}s timeout
+        </span>
+        {execution.env ? (
+          <AutomationEnvironmentVariables environment={execution.env} />
+        ) : null}
+      </div>
+    </ResourceDetailPanel>
+  );
+}
+
 export function AutomationDetailView({
   automation,
   projectLabel,
@@ -754,8 +793,10 @@ export function AutomationDetailView({
         <ResourceMeta
           items={[
             <AutomationMetadataItem
-              icon={personalProject ? "Laptop" : "Folder"}
-              iconLabel={personalProject ? "Local project" : "Project"}
+              icon="Folder"
+              iconLabel={
+                personalProject ? `Project: ${projectContextLabel}` : "Project"
+              }
               title={projectContextLabel}
             >
               {projectContextLabel}
@@ -839,35 +880,7 @@ export function AutomationDetailView({
               onUpdate={onUpdateAgent}
             />
           ) : (
-            <ResourceDetailPanel
-              surface="flat"
-              className="rounded-md border border-border bg-background"
-            >
-              {execution.script ? (
-                <AutomationScriptContent content={execution.script} />
-              ) : (
-                <div className="px-3 py-3 text-xs text-muted-foreground">
-                  Script content unavailable.
-                </div>
-              )}
-              <div className="flex min-w-0 flex-wrap items-center gap-x-4 gap-y-1.5 border-t border-border bg-surface-recessed/55 px-3 py-2 text-xs text-muted-foreground">
-                <span className="inline-flex items-center gap-1.5">
-                  <Icon
-                    name="ComputerTerminal01"
-                    className="size-3.5"
-                    aria-hidden
-                  />
-                  {execution.interpreter ?? "bash"}
-                </span>
-                <span className="inline-flex items-center gap-1.5">
-                  <Icon name="Clock" className="size-3.5" aria-hidden />
-                  {Math.round(execution.timeoutMs / 1000)}s timeout
-                </span>
-                {execution.env ? (
-                  <AutomationEnvironmentVariables environment={execution.env} />
-                ) : null}
-              </div>
-            </ResourceDetailPanel>
+            <ScriptAutomationDefinition execution={execution} />
           )}
         </ResourceDefinitionSection>
 

--- a/plugins/automations/overview-view.tsx
+++ b/plugins/automations/overview-view.tsx
@@ -158,7 +158,7 @@ export function automationProjectLabel(
   project: OverviewEntry["project"] | null | undefined,
 ): string {
   if (project == null) return "Workspace";
-  return project.id === PERSONAL_PROJECT_ID ? "Local" : project.name;
+  return project.name;
 }
 
 function automationProjectFilterId(
@@ -223,8 +223,8 @@ function AutomationRowMetadata({
     <ResourceMeta
       items={[
         <AutomationMetadataItem
-          icon={personalProject ? "Laptop" : "Folder"}
-          iconLabel={personalProject ? "Local project" : "Project"}
+          icon="Folder"
+          iconLabel={personalProject ? `Project: ${projectLabel}` : "Project"}
           title={projectLabel}
         >
           {projectLabel}
@@ -248,7 +248,7 @@ function AutomationRowMetadata({
   );
 }
 
-function OverviewRow({
+export function OverviewRow({
   automation,
   project,
   onNavigate,

--- a/plugins/automations/package.json
+++ b/plugins/automations/package.json
@@ -11,7 +11,7 @@
   },
   "engines": {
     "bb": ">=0.0",
-    "bbPluginSdk": ">=0.4.13"
+    "bbPluginSdk": ">=0.4.84"
   },
   "bb": {
     "name": "Automations",

--- a/plugins/automations/src/automation-provider-model-picker.test.tsx
+++ b/plugins/automations/src/automation-provider-model-picker.test.tsx
@@ -4,11 +4,15 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   ExperimentalPermissionModePickerProps,
+  ExperimentalProviderIconProps,
   ExperimentalProviderModelPickerProps,
 } from "@get-bb/plugin-sdk/app";
 import type { AgentExecutionUpdate, AutomationResponse } from "./rpc-types.js";
 
 vi.mock("@get-bb/plugin-sdk/app", () => ({
+  experimental_ProviderIcon: ({ provider }: ExperimentalProviderIconProps) => (
+    <span data-provider-icon={provider.id} />
+  ),
   experimental_ProviderModelPicker: ({
     onChange,
     routing,


### PR DESCRIPTION
## Human comments

## What was wrong

Automations displayed Personal project membership and personal workspaces as “Local,” and labeled all reused environments “Reuse worktree.” Workspace icons bypassed the shared provider renderer. Its Ladle detail stories also crashed because the Plugin SDK host controls were undefined, and the examples embedded full pages instead of showing focused component variants.

## What changed

- Show the server's Personal project name with a folder icon and “Project: Personal” tooltip. Rename the personal workspace label to “Personal workspace” and reuse labels to “Reuse environment,” with core's open-folder glyph.
- Render known workspace providers through `experimental_ProviderIcon`, using provider IDs and existing built-in glyph fallbacks. This supports registered icon overrides; it does not add provider-metadata fetching. Require SDK 0.4.84.
- Connect Ladle's SDK imports to the real host implementations and seed deterministic picker data. Replace full-page story rows with shared `StoryCard`/`StoryRow` variants for overview rows/states, prompt configurations, narrow/long metadata, scripts, and run states. Remove the Provider identities story.
- Export existing component pieces for stories and extract the script panel without changing its rendering behavior.

No new SDK APIs, database migrations, server/daemon wire changes, CLI flags, scheduling changes, or execution-placement changes. Parent PR #3535 is already merged and is excluded from this PR.

## How you verified

- Turbo app and Automations typechecks.
- Turbo focused app tests: automation overview and detail recipes, including Personal labels/search and provider-icon override registration/removal.
- Automations plugin test suite: 80 tests passed.
- Live Ladle checks: stories load without render errors; model picker opens; prompt edits save; reused/default/thread/worktree variants render; narrow labels and script-variable tooltips checked. Verified on desktop Chromium, including light theme. No native iOS verification claimed.
- `git diff --check`.

> AGENT GENERATED
