### PR TITLE
fix(app): place context tracker right of model selector

### DIFF
--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -598,9 +598,17 @@ function FollowUpPromptBoxWithComposer({
     (executionReadOnly ?? readOnly ?? false) || hasPendingInteraction;
   const footerStart = useMemo(
     () => (
-      <ExecutionControls {...execution} disabled={executionControlsDisabled} />
+      <>
+        <ExecutionControls
+          {...execution}
+          disabled={executionControlsDisabled}
+        />
+        {contextWindowUsage ? (
+          <ThreadContextWindowIndicator usage={contextWindowUsage} />
+        ) : null}
+      </>
     ),
-    [execution, executionControlsDisabled],
+    [contextWindowUsage, execution, executionControlsDisabled],
   );
   const selectedProviderPlanModeCopy = execution.provider.options?.find(
     (option) => option.value === execution.provider.selectedId,
@@ -775,9 +783,6 @@ function FollowUpPromptBoxWithComposer({
           </div>
           <div className="flex shrink-0 items-center gap-2">
             {permissionControl}
-            {contextWindowUsage ? (
-              <ThreadContextWindowIndicator usage={contextWindowUsage} />
-            ) : null}
           </div>
         </div>
       ) : null}


### PR DESCRIPTION
## Human comments

## What was wrong

The follow-up composer's context-window indicator mounted in the external footer's right-anchored group, after the permission picker. Each time it appeared or disappeared it pushed the permission picker sideways — a visible layout shift in a row meant to be stable.

## What changed

`apps/app/src/components/promptbox/FollowUpPromptBox.tsx`: `ThreadContextWindowIndicator` moved from the external footer's right group into `footerStart`, immediately after `ExecutionControls` (the model/reasoning picker). `footerStart` renders in the prompt box action row's left-anchored `flex-1` group, so the indicator now consumes flexible space to the right of the model selector: mounting or unmounting it moves nothing — the `+` menu and model chip sit to its left, and the voice/submit group is right-anchored separately. The external footer's right group now contains only the permission picker. Hidden-in-compact behavior is unchanged (the indicator lives in the `data-promptbox-expanded-only` group, matching the prior footer-hidden behavior).

No wire, CLI, or doc changes.

### Before / After

Before: tracker at the far right of the footer, after the permission picker.

![Composer footer before](https://raw.githubusercontent.com/smsunarto/bb/assets/pr-3554-screenshots/bb-composer-before.png)

After: tracker right of the model selector, inside the box.

![Composer footer after](https://raw.githubusercontent.com/smsunarto/bb/assets/pr-3554-screenshots/bb-composer-after.png)

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/app` — pass
- `pnpm exec turbo run lint --filter=@bb/app` — 0 errors
- Unit tests: 152 pass — `FollowUpPromptBox.test.tsx` (34), `ExecutionControls.test.tsx` (5), `PromptBoxInternal.test.tsx` (113)
- Live dev instance: accessibility snapshot of the composer shows `Provider, model and reasoning` → `Context window 13% used` adjacent inside the box, and the model selector's bounding-box x-position is identical (481px) on a thread with the indicator and one without it. Before/after composer screenshots were captured: before, the indicator sat at the footer's far right after "Accept Edits"; after, it sits inside the box right of the model chip.

> AGENT GENERATED
