### PR TITLE
Restore stdin EOF for repository lifecycle scripts

### DIFF
--- a/apps/host-daemon/src/environment-lifecycle-script.test.ts
+++ b/apps/host-daemon/src/environment-lifecycle-script.test.ts
@@ -30,6 +30,31 @@ afterEach(async () => {
 });
 
 describe("core environment scripts", () => {
+  it.each(["setup", "teardown"] as const)(
+    "supplies stdin EOF so %s continues to completion",
+    async (kind) => {
+      const workspacePath = await workspace(
+        kind,
+        'cat >/dev/null\nprintf complete > marker\nprintf "\\342"\nsleep 0.05\nprintf "\\234\\223\\n"\nprintf "done\\n" >&2\n',
+      );
+      const output: string[] = [];
+      const run = kind === "setup" ? runSetupScript : runTeardownScript;
+      const result = await run({
+        workspacePath,
+        timeoutMs: 1000,
+        env: { PATH: "/usr/bin:/bin" },
+        onProgress: (entry) => output.push(entry.text),
+      });
+      expect(result).toMatchObject({ ran: true, exitCode: 0 });
+      expect(await readFile(join(workspacePath, "marker"), "utf8")).toBe(
+        "complete",
+      );
+      expect(output).toContain("✓");
+      expect(output).toContain("done");
+      expect(result.output).toContain("✓\n");
+    },
+  );
+
   it("runs in the environment directory and streams stdout and stderr", async () => {
     const workspacePath = await workspace(
       "setup",

--- a/apps/host-daemon/src/environment-lifecycle-script.ts
+++ b/apps/host-daemon/src/environment-lifecycle-script.ts
@@ -4,7 +4,7 @@ import type { HostDaemonContributedEnvEntry } from "@bb/host-daemon-contract";
 import {
   isProcessGroupAlive,
   killProcessGroup,
-  spawnPortablePipedProcess,
+  spawnPortableOutputProcess,
   supportsProcessGroups,
 } from "@bb/process-utils";
 import fs from "node:fs/promises";
@@ -133,7 +133,7 @@ async function runLifecycleScript(
     },
     true,
   );
-  const child = spawnPortablePipedProcess({
+  const child = spawnPortableOutputProcess({
     command: command.command,
     args: command.args,
     cwd: args.workspacePath,


### PR DESCRIPTION
## Human comments

## What was wrong

Repository setup and teardown scripts were launched with piped stdin, but the host daemon never wrote to or closed that pipe. Any noninteractive hook that read stdin—for example, `cat >/dev/null` before doing its work—waited until the lifecycle timeout. Setup could prevent an environment from becoming ready, while teardown could skip cleanup commands after the read.

## What changed

- Launch repository lifecycle scripts with the existing output-only process helper, which supplies immediate stdin EOF while preserving piped stdout and stderr.
- Apply the same behavior to setup and teardown through their shared runner.
- Preserve contributed environment variables, streamed UTF-8 output, timeouts, cancellation, and process-group cleanup.
- No public API, CLI, configuration, or server/daemon wire contract changed. No protocol-version bump is needed.

## How you verified

- Added setup and teardown regressions that read stdin before writing a marker, emit split UTF-8 output, and write stderr. Both fail before the fix and pass after it.
- `pnpm exec turbo run test --filter=@bb/host-daemon --force -- src/environment-lifecycle-script.test.ts src/operation-environment.test.ts test/command/environment-hook.test.ts`: 20/20 passed.
- `pnpm exec turbo run build typecheck --filter=@bb/host-daemon --force`: passed.
- Targeted formatting and `git diff --check` passed.
- On a real Modal sandbox, repository setup received EOF, a real Codex agent completed its turn, and a separate disposable worktree's teardown received EOF and wrote its cleanup marker. The sandbox was suspended after verification.

Follow-up to #3274.

> AGENT GENERATED
