### PR TITLE
Keep plugin host calls responsive across environment changes

### DIFF
--- a/apps/host-daemon/src/plugin-host-manager.test.ts
+++ b/apps/host-daemon/src/plugin-host-manager.test.ts
@@ -58,9 +58,20 @@ export default {
       await context.experimental_emitSignal("changed", payload);
       return payload;
     },
-    async environment(input) {
+    async environment(input, context) {
       const before = process.env.GATE_VALUE;
-      await new Promise((resolve) => setTimeout(resolve, input.delay ?? 0));
+      if (input.id) await context.experimental_emitSignal("changed", { id: input.id, pid: process.pid });
+      await new Promise((resolve) => {
+        if (input.hang) return;
+        const finish = () => {
+          clearTimeout(timer);
+          context.signal.removeEventListener("abort", finish);
+          resolve();
+        };
+        const timer = setTimeout(finish, input.delay ?? 0);
+        context.signal.addEventListener("abort", finish, { once: true });
+        if (context.signal.aborted) finish();
+      });
       return { before: before ?? null, after: process.env.GATE_VALUE ?? null, token: process.env.GH_TOKEN ?? null };
     },
     echo(input) { return { input, pid: process.pid }; },
@@ -237,6 +248,211 @@ describe("PluginHostManager", () => {
       (await manager.call(callCommand({ method: "environment", input: {} })))
         .output,
     ).toEqual({ before: null, after: null, token: null });
+  });
+
+  describe("environment wait cancellation", () => {
+    async function fixture() {
+      const onSignal = vi.fn();
+      const onWorkerExit = vi.fn();
+      const manager = await createManager({
+        shellEnv: () => ({ GATE_VALUE: "base" }),
+        onSignal,
+        onWorkerExit,
+      });
+      const command = (id: string, value: string, delay = 0) =>
+        callCommand({
+          callId: id,
+          method: "environment",
+          input: { id, delay },
+          timeoutMs: 15_000,
+          contributedEnv: [
+            {
+              name: "GATE_VALUE",
+              value,
+              reason: "test",
+              source: { core: "machine-environment" },
+            },
+          ],
+        });
+      const cancel = (callId: string) =>
+        manager.cancel({
+          type: "plugin.host.cancel",
+          pluginId: "fixture",
+          generation: "generation-1",
+          callId,
+        });
+      const started = (id: string) =>
+        expect.objectContaining({
+          payload: expect.objectContaining({ id }),
+        });
+      const waitForStart = (id: string) =>
+        vi.waitFor(() => expect(onSignal).toHaveBeenCalledWith(started(id)));
+      return {
+        manager,
+        command,
+        cancel,
+        started,
+        waitForStart,
+        onSignal,
+        onWorkerExit,
+      };
+    }
+
+    it.each(["cancel", "deadline", "same-value"])(
+      "preserves a long running call and its PID after %s",
+      async (mode) => {
+        const {
+          manager,
+          command,
+          cancel,
+          started,
+          waitForStart,
+          onSignal,
+          onWorkerExit,
+        } = await fixture();
+        const initial = await manager.call(callCommand());
+        const running = Promise.allSettled([
+          manager.call(command("a", "first", 6500)),
+        ]);
+        await waitForStart("a");
+        const b = command(
+          "b",
+          mode === "same-value" ? "first" : "second",
+          10_000,
+        );
+        const cancelled = manager
+          .call({
+            ...b,
+            timeoutMs: mode === "deadline" ? 200 : b.timeoutMs,
+          })
+          .catch((error: unknown) => error);
+        if (mode === "same-value") await waitForStart("b");
+        else await new Promise((resolve) => setTimeout(resolve, 100));
+        if (mode !== "deadline") {
+          expect(cancel("b")).toEqual({ cancelled: true });
+          cancel("b");
+        }
+        const error = await cancelled;
+        if (mode === "deadline")
+          expect(error).toMatchObject({
+            message: expect.stringMatching(/deadline/u),
+          });
+        else expect(error).toMatchObject({ name: "AbortError" });
+        expect(await running).toMatchObject([
+          {
+            status: "fulfilled",
+            value: { output: { before: "first", after: "first" } },
+          },
+        ]);
+        if (mode !== "same-value")
+          expect(onSignal).not.toHaveBeenCalledWith(started("b"));
+        expect(
+          (await manager.call(command("c", "third"))).output,
+        ).toMatchObject({ before: "third", after: "third" });
+        expect(
+          (
+            await manager.call(
+              callCommand({ method: "environment", input: {} }),
+            )
+          ).output,
+        ).toMatchObject({ before: "base", after: "base" });
+        expect((await manager.call(callCommand())).output).toEqual(
+          initial.output,
+        );
+        expect(onWorkerExit).not.toHaveBeenCalled();
+      },
+    );
+
+    it("settles a cancelled waiter before release and lets other waiters rotate", async () => {
+      const { manager, command, cancel, waitForStart, onWorkerExit } =
+        await fixture();
+      const a = manager
+        .call(command("a", "first", 10_000))
+        .catch((error: unknown) => error);
+      await waitForStart("a");
+      const b = manager
+        .call(command("b", "second"))
+        .catch((error: unknown) => error);
+      const c = manager
+        .call(command("c", "third"))
+        .catch((error: unknown) => error);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      cancel("b");
+      await expect(b).resolves.toMatchObject({ name: "AbortError" });
+      expect(cancel("a")).toEqual({ cancelled: true });
+      await expect(a).resolves.toMatchObject({ name: "AbortError" });
+      await expect(c).resolves.toMatchObject({
+        output: { before: "third", after: "third" },
+      });
+      expect(onWorkerExit).not.toHaveBeenCalled();
+    });
+
+    it.each(["cancel-first", "release-first"])(
+      "handles %s with queued calls",
+      async (order) => {
+        const { manager, command, cancel, waitForStart, onWorkerExit } =
+          await fixture();
+        const a = manager
+          .call(command("a", "first", 10_000))
+          .catch((error: unknown) => error);
+        await waitForStart("a");
+        const b = manager
+          .call(command("b", "second", 10_000))
+          .catch((error: unknown) => error);
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        for (const id of order === "cancel-first" ? ["b", "a"] : ["a", "b"])
+          cancel(id);
+        await expect(a).resolves.toMatchObject({ name: "AbortError" });
+        await expect(b).resolves.toMatchObject({ name: "AbortError" });
+        await expect(
+          manager.call(command("c", "third")),
+        ).resolves.toMatchObject({
+          output: { before: "third", after: "third" },
+        });
+        expect(onWorkerExit).not.toHaveBeenCalled();
+      },
+    );
+
+    it("disposes with queued calls and starts a fresh generation", async () => {
+      const { manager, command, waitForStart } = await fixture();
+      const a = manager
+        .call(command("a", "first", 10_000))
+        .catch((error: unknown) => error);
+      await waitForStart("a");
+      const b = manager
+        .call(command("b", "second"))
+        .catch((error: unknown) => error);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await manager.dispose({
+        type: "plugin.host.dispose",
+        pluginId: "fixture",
+        generation: "generation-1",
+      });
+      expect(await a).toBeInstanceOf(Error);
+      expect(await b).toBeInstanceOf(Error);
+      await expect(
+        manager.call({ ...command("c", "third"), generation: "generation-2" }),
+      ).resolves.toMatchObject({ output: { before: "third", after: "third" } });
+    });
+
+    it("still force-kills a started handler that ignores cancellation", async () => {
+      const { manager, command, cancel, waitForStart, onWorkerExit } =
+        await fixture();
+      const initial = await manager.call(callCommand());
+      const hung = manager
+        .call({
+          ...command("hung", "first"),
+          input: { id: "hung", hang: true },
+        })
+        .catch((error: unknown) => error);
+      await waitForStart("hung");
+      cancel("hung");
+      await expect(hung).resolves.toMatchObject({ name: "AbortError" });
+      expect(onWorkerExit).toHaveBeenCalledOnce();
+      expect((await manager.call(callCommand())).output).not.toEqual(
+        initial.output,
+      );
+    });
   });
 
   it.each(["type", "true", "changed"])(

--- a/apps/host-daemon/src/plugin-host-manager.test.ts
+++ b/apps/host-daemon/src/plugin-host-manager.test.ts
@@ -200,7 +200,7 @@ describe("PluginHostManager", () => {
     expect(fetchArtifact).toHaveBeenCalledOnce();
   });
 
-  it("scopes setup env, waits for rotation, and returns worker output as-is", async () => {
+  it("scopes setup env, rotates while idle, and returns worker output as-is", async () => {
     const manager = await createManager({
       shellEnv: () => ({ npm_config_user_agent: "test" }),
     });
@@ -218,22 +218,22 @@ describe("PluginHostManager", () => {
         source: { core: "machine-git" as const },
       },
     ];
-    const [first, rotated] = await Promise.all([
-      manager.call(
+    const [first, rotated] = [
+      await manager.call(
         callCommand({
           method: "environment",
           input: { delay: 100 },
           contributedEnv: contribution("first"),
         }),
       ),
-      manager.call(
+      await manager.call(
         callCommand({
           method: "environment",
           input: {},
           contributedEnv: contribution("rotated"),
         }),
       ),
-    ]);
+    ];
     expect(first.output).toEqual({
       before: "first",
       after: "first",
@@ -250,7 +250,7 @@ describe("PluginHostManager", () => {
     ).toEqual({ before: null, after: null, token: null });
   });
 
-  describe("environment wait cancellation", () => {
+  describe("environment reuse across active calls", () => {
     async function fixture() {
       const onSignal = vi.fn();
       const onWorkerExit = vi.fn();
@@ -326,8 +326,7 @@ describe("PluginHostManager", () => {
             timeoutMs: mode === "deadline" ? 200 : b.timeoutMs,
           })
           .catch((error: unknown) => error);
-        if (mode === "same-value") await waitForStart("b");
-        else await new Promise((resolve) => setTimeout(resolve, 100));
+        await waitForStart("b");
         if (mode !== "deadline") {
           expect(cancel("b")).toEqual({ cancelled: true });
           cancel("b");
@@ -344,8 +343,7 @@ describe("PluginHostManager", () => {
             value: { output: { before: "first", after: "first" } },
           },
         ]);
-        if (mode !== "same-value")
-          expect(onSignal).not.toHaveBeenCalledWith(started("b"));
+        expect(onSignal).toHaveBeenCalledWith(started("b"));
         expect(
           (await manager.call(command("c", "third"))).output,
         ).toMatchObject({ before: "third", after: "third" });
@@ -363,66 +361,40 @@ describe("PluginHostManager", () => {
       },
     );
 
-    it("settles a cancelled waiter before release and lets other waiters rotate", async () => {
-      const { manager, command, cancel, waitForStart, onWorkerExit } =
-        await fixture();
+    it("keeps the first values until every overlapping call finishes", async () => {
+      const { manager, command, cancel, waitForStart } = await fixture();
       const a = manager
         .call(command("a", "first", 10_000))
         .catch((error: unknown) => error);
       await waitForStart("a");
       const b = manager
-        .call(command("b", "second"))
+        .call(command("b", "second", 10_000))
         .catch((error: unknown) => error);
-      const c = manager
-        .call(command("c", "third"))
-        .catch((error: unknown) => error);
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await waitForStart("b");
+      cancel("a");
+      await expect(a).resolves.toMatchObject({ name: "AbortError" });
+      await expect(manager.call(command("c", "third"))).resolves.toMatchObject({
+        output: { before: "first", after: "first" },
+      });
       cancel("b");
       await expect(b).resolves.toMatchObject({ name: "AbortError" });
-      expect(cancel("a")).toEqual({ cancelled: true });
-      await expect(a).resolves.toMatchObject({ name: "AbortError" });
-      await expect(c).resolves.toMatchObject({
-        output: { before: "third", after: "third" },
-      });
-      expect(onWorkerExit).not.toHaveBeenCalled();
+      await expect(manager.call(command("d", "fourth"))).resolves.toMatchObject(
+        {
+          output: { before: "fourth", after: "fourth" },
+        },
+      );
     });
 
-    it.each(["cancel-first", "release-first"])(
-      "handles %s with queued calls",
-      async (order) => {
-        const { manager, command, cancel, waitForStart, onWorkerExit } =
-          await fixture();
-        const a = manager
-          .call(command("a", "first", 10_000))
-          .catch((error: unknown) => error);
-        await waitForStart("a");
-        const b = manager
-          .call(command("b", "second", 10_000))
-          .catch((error: unknown) => error);
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        for (const id of order === "cancel-first" ? ["b", "a"] : ["a", "b"])
-          cancel(id);
-        await expect(a).resolves.toMatchObject({ name: "AbortError" });
-        await expect(b).resolves.toMatchObject({ name: "AbortError" });
-        await expect(
-          manager.call(command("c", "third")),
-        ).resolves.toMatchObject({
-          output: { before: "third", after: "third" },
-        });
-        expect(onWorkerExit).not.toHaveBeenCalled();
-      },
-    );
-
-    it("disposes with queued calls and starts a fresh generation", async () => {
+    it("disposes with overlapping calls and starts a fresh generation", async () => {
       const { manager, command, waitForStart } = await fixture();
       const a = manager
         .call(command("a", "first", 10_000))
         .catch((error: unknown) => error);
       await waitForStart("a");
       const b = manager
-        .call(command("b", "second"))
+        .call(command("b", "second", 10_000))
         .catch((error: unknown) => error);
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await waitForStart("b");
       await manager.dispose({
         type: "plugin.host.dispose",
         pluginId: "fixture",

--- a/apps/host-daemon/src/plugin-host-worker.ts
+++ b/apps/host-daemon/src/plugin-host-worker.ts
@@ -7,27 +7,7 @@ function createOperationEnvironmentScope(target: NodeJS.ProcessEnv) {
   let active = 0;
   let current: Record<string, string> = {};
   let previous: NodeJS.ProcessEnv = {};
-  let waiters: Array<() => void> = [];
-  return async (
-    env: Record<string, string>,
-    signal: AbortSignal,
-  ): Promise<() => void> => {
-    signal.throwIfAborted();
-    const same = () =>
-      Object.keys(current).length === Object.keys(env).length &&
-      Object.entries(env).every(([key, value]) => current[key] === value);
-    while (active > 0 && !same()) {
-      await new Promise<void>((resolve) => {
-        const resume = () => {
-          signal.removeEventListener("abort", resume);
-          waiters = waiters.filter((waiter) => waiter !== resume);
-          resolve();
-        };
-        waiters.push(resume);
-        signal.addEventListener("abort", resume, { once: true });
-      });
-      signal.throwIfAborted();
-    }
+  return (env: Record<string, string>): (() => void) => {
     if (active === 0) {
       current = env;
       previous = {};
@@ -46,9 +26,6 @@ function createOperationEnvironmentScope(target: NodeJS.ProcessEnv) {
       }
       current = {};
       previous = {};
-      const ready = waiters;
-      waiters = [];
-      for (const resolve of ready) resolve();
     };
   };
 }
@@ -552,10 +529,7 @@ async function handleCall(
   let contextOpen = true;
   let releaseEnvironment: (() => void) | undefined;
   try {
-    releaseEnvironment = await acquireEnvironment(
-      message.envVars,
-      controller.signal,
-    );
+    releaseEnvironment = acquireEnvironment(message.envVars);
     controller.signal.throwIfAborted();
     const input = await validate(method.input, message.input);
     const result = await handler(input, {

--- a/apps/host-daemon/src/plugin-host-worker.ts
+++ b/apps/host-daemon/src/plugin-host-worker.ts
@@ -8,12 +8,26 @@ function createOperationEnvironmentScope(target: NodeJS.ProcessEnv) {
   let current: Record<string, string> = {};
   let previous: NodeJS.ProcessEnv = {};
   let waiters: Array<() => void> = [];
-  return async (env: Record<string, string>): Promise<() => void> => {
+  return async (
+    env: Record<string, string>,
+    signal: AbortSignal,
+  ): Promise<() => void> => {
+    signal.throwIfAborted();
     const same = () =>
       Object.keys(current).length === Object.keys(env).length &&
       Object.entries(env).every(([key, value]) => current[key] === value);
-    while (active > 0 && !same())
-      await new Promise<void>((resolve) => waiters.push(resolve));
+    while (active > 0 && !same()) {
+      await new Promise<void>((resolve) => {
+        const resume = () => {
+          signal.removeEventListener("abort", resume);
+          waiters = waiters.filter((waiter) => waiter !== resume);
+          resolve();
+        };
+        waiters.push(resume);
+        signal.addEventListener("abort", resume, { once: true });
+      });
+      signal.throwIfAborted();
+    }
     if (active === 0) {
       current = env;
       previous = {};
@@ -536,8 +550,12 @@ async function handleCall(
   const controller = new AbortController();
   activeCalls.set(message.callId, controller);
   let contextOpen = true;
-  const releaseEnvironment = await acquireEnvironment(message.envVars);
+  let releaseEnvironment: (() => void) | undefined;
   try {
+    releaseEnvironment = await acquireEnvironment(
+      message.envVars,
+      controller.signal,
+    );
     controller.signal.throwIfAborted();
     const input = await validate(method.input, message.input);
     const result = await handler(input, {
@@ -594,7 +612,7 @@ async function handleCall(
   } finally {
     contextOpen = false;
     activeCalls.delete(message.callId);
-    releaseEnvironment();
+    releaseEnvironment?.();
   }
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1341,8 +1341,9 @@ are active in that plugin worker. Changed or removed machine variables take
 effect on the next call after all active calls finish. Continuous overlapping
 calls can keep the previous values until the worker becomes idle.
 
-Ordinary setup variable delivery requires host-daemon protocol 205. Older
-daemons must update before the server accepts their session.
+Ordinary setup variable delivery requires host-daemon protocol 205; immediate
+plugin-call reuse across environment changes requires protocol 206. Older daemons
+must update before the server accepts their session.
 
 The built-in GitHub row uses `gh auth token --hostname github.com` and `gh api
 --hostname github.com user` on the server host. It supplies `GH_TOKEN`, Git's

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1336,6 +1336,11 @@ the environment they started with: open a new terminal after a change. Agent
 turns receive refreshed values on their next turn and after resume. Codex rebuilds
 its loaded session from the existing conversation when the environment changes.
 
+Plugin host calls start immediately using the current environment while any calls
+are active in that plugin worker. Changed or removed machine variables take
+effect on the next call after all active calls finish. Continuous overlapping
+calls can keep the previous values until the worker becomes idle.
+
 Ordinary setup variable delivery requires host-daemon protocol 205. Older
 daemons must update before the server accepts their session.
 

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,3 @@
-export const HOST_DAEMON_PROTOCOL_VERSION = 205 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 206 as const;
 
 export const HOST_ARTIFACT_MAX_BYTES = 256 * 1024 * 1024;

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -999,7 +999,7 @@ const CONTRIBUTED_ENV = [
 
 describe("host-daemon command schemas", () => {
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(205);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(206);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/templates/src/templates/bb-guide-machines.md
+++ b/packages/templates/src/templates/bb-guide-machines.md
@@ -274,6 +274,11 @@ apply to the next turn, setup operation, or newly opened BB terminal; existing
 terminals retain their launch environment. Runtime output is forwarded as-is,
 so commands and providers can print contributed values.
 
+Plugin host calls start immediately using the current environment while any calls
+are active in that plugin worker. Changed or removed machine variables take
+effect on the next call after all active calls finish. Continuous overlapping
+calls can keep the previous values until the worker becomes idle.
+
 The server's gh login provides GitHub credentials, a Git environment-only HTTPS
 helper and SSH rewrites, and commit identity. The built-in row reports logged in,
 not logged in, or overridden. No credentials are installed in images or global

--- a/plugins/bb-guide/skills/bb-cli/references/configuration.md
+++ b/plugins/bb-guide/skills/bb-cli/references/configuration.md
@@ -136,3 +136,8 @@ agent-provider entries override host values. Reopen existing terminals after a
 change. The server gh login provides GitHub Git/gh authentication and commit
 identity by default; a user GH_TOKEN replaces it. See Settings → Machines →
 Machine environment, and `bb machine env list` for builtInGit readiness.
+
+Plugin host calls start immediately using the current environment while any calls
+are active in that plugin worker. Changed or removed machine variables take
+effect on the next call after all active calls finish. Continuous overlapping
+calls can keep the previous values until the worker becomes idle.


### PR DESCRIPTION
## Human comments

## What was wrong

Plugin host calls share a process and its environment. After #3274, a call needing changed machine variables waited for all active calls to finish. That could block a stop/close call behind the long-running work it was meant to stop. Cancelling a waiting call could also trigger the manager's five-second force-kill timer and interrupt unrelated calls in the same worker.

## What changed

Remove the environment wait queue. While any calls are active, incoming calls run immediately using the worker's current environment, even if they supply different values. Once all calls finish, the next incoming call supplies fresh values. Values from overlapping calls are not saved as pending updates. Continuous overlapping work can intentionally retain old settings until the worker becomes idle.

The environment is restored when the last active call finishes. Existing cancellation and force-kill protection for unresponsive handlers remain intact. Acquisition stays inside the call's error cleanup.

Bump `HOST_DAEMON_PROTOCOL_VERSION` from 205 to 206 so enrolled machines update for the changed environment semantics. Document when plugin calls adopt settings in the machine CLI guide, configuration docs, and bb-cli skill reference. No new CLI flags or public SDK members. This PR does not touch UI code.

## How you verified

- Updated real-worker regression coverage for immediate admission with different values, retaining the first values until every overlapping call finishes, adopting the next idle call's values, variable removal, cancellation/deadlines, disposal, and hung-handler termination. Four tests failed with the previous waiting implementation; all 32 plugin host manager tests pass after the change.
- Post-rebase `pnpm exec turbo run test build typecheck --filter=@bb/host-daemon --filter=@bb/host-daemon-contract --force` — 617 daemon tests and 56 contract tests passed; all 11 Turbo tasks passed.
- Actual browser-plugin host handlers running through the real manager, worker process, and IPC, with an injected cooperative runtime: previously close waited behind a two-second run after a variable change; now it interrupts the run and returns in 1 ms with either unchanged or changed values.
- Verified through the actual built `bb` CLI, isolated source server, enrolled built daemon, and a diagnostic plugin installed with `bb plugin install`. Two 20-second calls overlapped across a machine-variable update and retained the old values in one worker PID; stop commands returned in 268 ms and 259 ms; the first idle call adopted the new values and later reflected removal.
- Targeted formatting and `git diff --check origin/main...HEAD` passed.

> AGENT GENERATED
