### PR TITLE
Fix read recovery after optimistic cache updates

### DIFF
--- a/apps/app/src/hooks/cache-owners/thread-state-cache-owner.test.ts
+++ b/apps/app/src/hooks/cache-owners/thread-state-cache-owner.test.ts
@@ -17,6 +17,7 @@ import {
   beginThreadReadStateTransaction,
   beginThreadMetadataTransaction,
   rollbackThreadListMutationTransaction,
+  rollbackThreadReadStateTransaction,
 } from "./thread-state-cache-owner";
 
 function makeThreadWithRuntime(
@@ -287,3 +288,68 @@ describe("thread state cache owner", () => {
     ).toBe(10);
   });
 });
+
+it.each([null, 80, 100])(
+  "rolls back only the pending read, preserving newer fields and sibling caches (%s)",
+  async (lastReadAt) => {
+    const { queryClient } = createQueryClientTestHarness();
+    const threadId = "thread-1";
+    const listKey = threadListQueryKey({
+      archived: false,
+      projectId: "project-1",
+    });
+    const original = makeThreadListEntry({
+      id: threadId,
+      lastReadAt: 10,
+      latestAttentionAt: 20,
+    });
+    queryClient.setQueryData(
+      threadQueryKey(threadId),
+      makeThreadWithRuntime(original),
+    );
+    queryClient.setQueryData(listKey, [original]);
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      makeSidebarNavigation([original]),
+    );
+    const transaction = await beginThreadReadStateTransaction({
+      queryClient,
+      threadId,
+      lastReadAt: 100,
+    });
+    const updated = makeThreadListEntry({
+      ...original,
+      lastReadAt,
+      latestAttentionAt: 200,
+      title: "New title",
+    });
+    const sibling = makeThreadListEntry({ id: "new-sibling", lastReadAt: 300 });
+    queryClient.setQueryData(
+      threadQueryKey(threadId),
+      makeThreadWithRuntime(updated),
+    );
+    queryClient.setQueryData(listKey, [updated, sibling]);
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      makeSidebarNavigation([updated, sibling]),
+    );
+    rollbackThreadReadStateTransaction({ queryClient, threadId, transaction });
+    const expected = {
+      lastReadAt: lastReadAt === 100 ? 10 : lastReadAt,
+      latestAttentionAt: 200,
+      title: "New title",
+    };
+    expect(queryClient.getQueryData(threadQueryKey(threadId))).toMatchObject(
+      expected,
+    );
+    expect(queryClient.getQueryData<ThreadListEntry[]>(listKey)).toEqual([
+      expect.objectContaining(expected),
+      sibling,
+    ]);
+    expect(
+      queryClient.getQueryData<SidebarBootstrapResponse>(
+        sidebarNavigationQueryKey(),
+      )?.projects[0]?.threads,
+    ).toEqual([expect.objectContaining(expected), sibling]);
+  },
+);

--- a/apps/app/src/hooks/cache-owners/thread-state-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/thread-state-cache-owner.ts
@@ -22,12 +22,15 @@ import {
 } from "./mutation-cache-effects";
 import {
   applyToCachedThreadListsAndSidebarNavigation,
+  applyToCachedSidebarNavigationThreads,
+  listSidebarNavigationThreads,
   getCachedSidebarNavigationThreads,
   restoreCachedSidebarNavigation,
   snapshotCachedSidebarNavigation,
   type CachedSidebarNavigationSnapshot,
 } from "./query-cache";
 import {
+  applyToCachedThreadLists,
   getCachedThreadLists,
   iterateThreadListCacheEntries,
   restoreCachedThreadLists,
@@ -365,12 +368,12 @@ export function beginUnpinAndMoveThreadTransaction({
   });
 }
 
-export function beginThreadReadStateTransaction({
+export async function beginThreadReadStateTransaction({
   lastReadAt,
   queryClient,
   threadId,
-}: BeginThreadReadStateTransactionArgs): Promise<ThreadListMutationTransaction> {
-  return runOptimisticThreadFieldTransaction({
+}: BeginThreadReadStateTransactionArgs): Promise<ThreadReadStateTransaction> {
+  const transaction = await runOptimisticThreadFieldTransaction({
     applyToLists: (queryClient, threadId) =>
       applyToCachedThreadListsAndSidebarNavigation(queryClient, (list) =>
         list.map((thread) =>
@@ -388,6 +391,61 @@ export function beginThreadReadStateTransaction({
     }),
     queryClient,
     threadId,
+  });
+  return { ...transaction, lastReadAt };
+}
+
+export interface ThreadReadStateTransaction extends ThreadListMutationTransaction {
+  lastReadAt: number | null;
+}
+
+export function rollbackThreadReadStateTransaction({
+  queryClient,
+  threadId,
+  transaction,
+}: ThreadIdCacheArgs & {
+  transaction: ThreadReadStateTransaction | undefined;
+}): void {
+  if (!transaction) return;
+  const { lastReadAt } = transaction;
+  function restore<
+    T extends Pick<
+      ThreadWithRuntime,
+      "id" | "lastReadAt" | "latestAttentionAt"
+    >,
+  >(
+    current: T,
+    previous:
+      | Pick<ThreadWithRuntime, "lastReadAt" | "latestAttentionAt">
+      | undefined,
+  ): T {
+    return current.id === threadId &&
+      previous &&
+      current.lastReadAt === getOptimisticLastReadAt(previous, lastReadAt)
+      ? { ...current, lastReadAt: previous.lastReadAt }
+      : current;
+  }
+  queryClient.setQueryData<ThreadWithRuntime>(
+    threadQueryKey(threadId),
+    (current) => current && restore(current, transaction.previousThread),
+  );
+  for (const snapshot of transaction.previousThreadLists) {
+    const previous = [...iterateThreadListCacheEntries(snapshot.data)].find(
+      (thread) => thread.id === threadId,
+    );
+    applyToCachedThreadLists(queryClient, {
+      queryKey: snapshot.queryKey,
+      mapper: (list) => list.map((thread) => restore(thread, previous)),
+    });
+  }
+  const previous = transaction.previousSidebarNavigation
+    ? listSidebarNavigationThreads(transaction.previousSidebarNavigation).find(
+        (thread) => thread.id === threadId,
+      )
+    : undefined;
+  applyToCachedSidebarNavigationThreads({
+    queryClient,
+    mapper: (list) => list.map((thread) => restore(thread, previous)),
   });
 }
 

--- a/apps/app/src/hooks/mutations/thread-state-mutations.ts
+++ b/apps/app/src/hooks/mutations/thread-state-mutations.ts
@@ -27,6 +27,8 @@ import {
   rollbackDeleteThreadTransaction,
   rollbackReorderPinnedThreadTransaction,
   rollbackThreadListMutationTransaction,
+  rollbackThreadReadStateTransaction,
+  type ThreadReadStateTransaction,
   settleArchiveThreadsTransaction,
   settleDeleteThreadTransaction,
   settleThreadListMembershipMutation,
@@ -380,16 +382,15 @@ export function useMarkThreadRead() {
       errorMessage: "Failed to mark thread read.",
       showErrorToast: false,
     },
-    mutationFn: (input: ThreadReadMutationInput) =>
-      sdk.threads.markRead(input),
-    onMutate: (input): Promise<ThreadListMutationTransaction> =>
+    mutationFn: (input: ThreadReadMutationInput) => sdk.threads.markRead(input),
+    onMutate: (input): Promise<ThreadReadStateTransaction> =>
       beginThreadReadStateTransaction({
         lastReadAt: Date.now(),
         queryClient,
         threadId: input.threadId,
       }),
     onError: (_error, input, context) => {
-      rollbackThreadListMutationTransaction({
+      rollbackThreadReadStateTransaction({
         queryClient,
         threadId: input.threadId,
         transaction: context,

--- a/apps/app/src/hooks/useThreadReadTracking.integration.test.tsx
+++ b/apps/app/src/hooks/useThreadReadTracking.integration.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+
+import { StrictMode } from "react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { useQuery } from "@tanstack/react-query";
+import type { ThreadWithRuntime } from "@bb/domain";
+import { makeThreadWithRuntime } from "@bb/test-helpers/domain-fixtures";
+import { afterEach, expect, it, vi } from "vitest";
+import { makeThreadResponse } from "@/test/fixtures/thread-responses";
+import { sdk } from "@/lib/sdk";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import {
+  useMarkThreadRead,
+  useMarkThreadUnread,
+} from "./mutations/thread-state-mutations";
+import { threadQueryKey } from "./queries/query-keys";
+import { useThreadReadTracking } from "./useThreadReadTracking";
+
+vi.mock("@/lib/sdk", () => ({
+  sdk: { threads: { markRead: vi.fn(), markUnread: vi.fn() } },
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+function setup(deferAbort = false) {
+  const harness = createQueryClientTestHarness();
+  const requests: {
+    signal: AbortSignal | undefined;
+    threadId: string;
+    resolve: () => void;
+    reject: () => void;
+  }[] = [];
+  for (const id of ["A", "B"]) {
+    harness.queryClient.setQueryData(
+      threadQueryKey(id),
+      makeThreadWithRuntime({ id, lastReadAt: 10, latestAttentionAt: 20 }),
+    );
+  }
+  vi.mocked(sdk.threads.markRead).mockImplementation(
+    ({ threadId, signal }) =>
+      new Promise((resolve, reject) => {
+        signal?.throwIfAborted();
+        requests.push({
+          signal,
+          threadId,
+          reject: () => reject(new DOMException("Aborted", "AbortError")),
+          resolve: () =>
+            resolve(
+              makeThreadResponse({
+                id: threadId,
+                lastReadAt: 20,
+                latestAttentionAt: 20,
+              }),
+            ),
+        });
+        if (!deferAbort)
+          signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+      }),
+  );
+  const mount = () =>
+    renderHook(
+      ({ id }) => {
+        const query = useQuery<ThreadWithRuntime>({
+          queryKey: threadQueryKey(id),
+          enabled: false,
+        });
+        useThreadReadTracking({
+          thread: query.data,
+          markThreadRead: useMarkThreadRead(),
+        });
+        return useMarkThreadUnread();
+      },
+      {
+        initialProps: { id: "A" },
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <harness.wrapper>{children}</harness.wrapper>
+          </StrictMode>
+        ),
+      },
+    );
+  return { ...harness, ...mount(), requests, mount };
+}
+
+it("cancels optimistic reads on departure and retries after reopening", async () => {
+  const { rerender, requests, queryClient } = setup();
+  await waitFor(() => expect(requests).toHaveLength(1));
+  expect(
+    queryClient.getQueryData<ThreadWithRuntime>(threadQueryKey("A"))
+      ?.lastReadAt,
+  ).toBeGreaterThan(20);
+  rerender({ id: "B" });
+  await waitFor(() => expect(requests[0]?.signal?.aborted).toBe(true));
+  await waitFor(() => expect(requests).toHaveLength(2));
+  rerender({ id: "A" });
+  await waitFor(() => expect(requests).toHaveLength(3));
+  expect(requests[1]?.signal?.aborted).toBe(true);
+  expect(requests[2]?.threadId).toBe("A");
+  expect(requests[2]?.signal?.aborted).toBe(false);
+});
+
+it("rolls back an optimistic read after unmount so a new mount can retry", async () => {
+  const { unmount, requests, queryClient, mount } = setup();
+  await waitFor(() => expect(requests).toHaveLength(1));
+  unmount();
+  await waitFor(() => expect(requests[0]?.signal?.aborted).toBe(true));
+  await waitFor(() =>
+    expect(
+      queryClient.getQueryData<ThreadWithRuntime>(threadQueryKey("A"))
+        ?.lastReadAt,
+    ).toBe(10),
+  );
+  mount();
+  await waitFor(() => expect(requests).toHaveLength(2));
+});
+
+it("keeps a completed read and respects manual unread until new attention", async () => {
+  const { requests, result, queryClient } = setup();
+  await waitFor(() => expect(requests).toHaveLength(1));
+  await act(async () => requests[0]?.resolve());
+  vi.mocked(sdk.threads.markUnread).mockResolvedValue(
+    makeThreadResponse({ id: "A", lastReadAt: null, latestAttentionAt: 20 }),
+  );
+  await act(async () => {
+    await result.current.mutateAsync({ threadId: "A" });
+  });
+  act(() => window.dispatchEvent(new Event("pageshow")));
+  expect(requests).toHaveLength(1);
+  expect(
+    queryClient.getQueryData<ThreadWithRuntime>(threadQueryKey("A"))
+      ?.lastReadAt,
+  ).toBeNull();
+  act(() =>
+    queryClient.setQueryData<ThreadWithRuntime>(
+      threadQueryKey("A"),
+      (thread) => thread && { ...thread, latestAttentionAt: 30 },
+    ),
+  );
+  await waitFor(() => expect(requests).toHaveLength(2));
+});
+
+it("does not undo a newer manual unread when an older read is cancelled", async () => {
+  const { requests, result, rerender, queryClient } = setup();
+  await waitFor(() => expect(requests).toHaveLength(1));
+  vi.mocked(sdk.threads.markUnread).mockResolvedValue(
+    makeThreadResponse({ id: "A", lastReadAt: null, latestAttentionAt: 20 }),
+  );
+  await act(async () => {
+    await result.current.mutateAsync({ threadId: "A" });
+  });
+  rerender({ id: "B" });
+  await waitFor(() => expect(requests[0]?.signal?.aborted).toBe(true));
+  await waitFor(() => expect(queryClient.isMutating()).toBe(1));
+  expect(
+    queryClient.getQueryData<ThreadWithRuntime>(threadQueryKey("A"))
+      ?.lastReadAt,
+  ).toBeNull();
+});
+
+it("cancels every attention request without rolling back newer thread data", async () => {
+  const { requests, queryClient, unmount } = setup();
+  await waitFor(() => expect(requests).toHaveLength(1));
+  act(() =>
+    queryClient.setQueryData<ThreadWithRuntime>(
+      threadQueryKey("A"),
+      (thread) =>
+        thread && {
+          ...thread,
+          title: "New title",
+          latestAttentionAt: Date.now() + 1000,
+        },
+    ),
+  );
+  await waitFor(() => expect(requests).toHaveLength(2));
+  const attention = queryClient.getQueryData<ThreadWithRuntime>(
+    threadQueryKey("A"),
+  )?.latestAttentionAt;
+  unmount();
+  await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+  expect(requests.every((request) => request.signal?.aborted)).toBe(true);
+  expect(
+    queryClient.getQueryData<ThreadWithRuntime>(threadQueryKey("A")),
+  ).toMatchObject({ title: "New title", latestAttentionAt: attention });
+});
+
+it("retries after returning before the cancelled request has finished", async () => {
+  const { requests, rerender } = setup(true);
+  await waitFor(() => expect(requests).toHaveLength(1));
+  rerender({ id: "B" });
+  await waitFor(() => expect(requests).toHaveLength(2));
+  rerender({ id: "A" });
+  expect(requests[0]?.signal?.aborted).toBe(true);
+  await act(async () => requests[0]?.reject());
+  await waitFor(() => expect(requests).toHaveLength(3));
+  expect(requests[2]?.threadId).toBe("A");
+  await act(async () => requests[1]?.reject());
+  expect(requests[2]?.signal?.aborted).toBe(false);
+});

--- a/apps/app/src/hooks/useThreadReadTracking.test.tsx
+++ b/apps/app/src/hooks/useThreadReadTracking.test.tsx
@@ -7,7 +7,6 @@ import { useThreadReadTracking } from "./useThreadReadTracking";
 type MarkThreadReadMutation = Parameters<
   typeof useThreadReadTracking
 >[0]["markThreadRead"];
-type MutateOptions = Parameters<MarkThreadReadMutation["mutate"]>[1];
 type TestThread = {
   id: string;
   lastReadAt: number | null;
@@ -16,7 +15,16 @@ type TestThread = {
 
 function makeMarkThreadRead() {
   return {
-    mutate: vi.fn<MarkThreadReadMutation["mutate"]>(),
+    mutateAsync: vi.fn<MarkThreadReadMutation["mutateAsync"]>(
+      ({ signal }) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener(
+            "abort",
+            () => reject(new Error("Aborted")),
+            { once: true },
+          );
+        }),
+    ),
   } satisfies MarkThreadReadMutation;
 }
 
@@ -45,7 +53,7 @@ describe("useThreadReadTracking", () => {
       }),
     );
 
-    expect(markThreadRead.mutate).not.toHaveBeenCalled();
+    expect(markThreadRead.mutateAsync).not.toHaveBeenCalled();
   });
 
   it("marks an unread thread read after a mobile pageshow restore", () => {
@@ -63,17 +71,16 @@ describe("useThreadReadTracking", () => {
       }),
     );
 
-    expect(markThreadRead.mutate).not.toHaveBeenCalled();
+    expect(markThreadRead.mutateAsync).not.toHaveBeenCalled();
 
     act(() => {
       setDocumentVisibilityState("visible");
       window.dispatchEvent(new Event("pageshow"));
     });
 
-    expect(markThreadRead.mutate).toHaveBeenCalledTimes(1);
-    expect(markThreadRead.mutate).toHaveBeenLastCalledWith(
+    expect(markThreadRead.mutateAsync).toHaveBeenCalledTimes(1);
+    expect(markThreadRead.mutateAsync).toHaveBeenLastCalledWith(
       expect.objectContaining({ threadId: "thr_mobile_restore" }),
-      expect.objectContaining({ onError: expect.any(Function) }),
     );
   });
 
@@ -92,21 +99,21 @@ describe("useThreadReadTracking", () => {
       { initialProps: { latestAttentionAt: 20 } },
     );
 
-    expect(markThreadRead.mutate).toHaveBeenCalledTimes(1);
-    expect(markThreadRead.mutate).toHaveBeenLastCalledWith(
+    expect(markThreadRead.mutateAsync).toHaveBeenCalledTimes(1);
+    expect(markThreadRead.mutateAsync).toHaveBeenLastCalledWith(
       expect.objectContaining({ threadId: "thr_side_chat" }),
-      expect.objectContaining({ onError: expect.any(Function) }),
     );
 
     rerender({ latestAttentionAt: 20 });
-    expect(markThreadRead.mutate).toHaveBeenCalledTimes(1);
+    expect(markThreadRead.mutateAsync).toHaveBeenCalledTimes(1);
 
     rerender({ latestAttentionAt: 30 });
-    expect(markThreadRead.mutate).toHaveBeenCalledTimes(2);
+    expect(markThreadRead.mutateAsync).toHaveBeenCalledTimes(2);
   });
 
-  it("retries a failed read after pageshow while already visible", () => {
+  it("retries a failed read after pageshow while already visible", async () => {
     const markThreadRead = makeMarkThreadRead();
+    markThreadRead.mutateAsync.mockRejectedValueOnce(new Error("Failed"));
     renderHook(() =>
       useThreadReadTracking({
         markThreadRead,
@@ -117,15 +124,12 @@ describe("useThreadReadTracking", () => {
         },
       }),
     );
-    const options: MutateOptions | undefined =
-      markThreadRead.mutate.mock.calls[0]?.[1];
-
-    options?.onError?.();
+    await act(async () => {});
     act(() => {
       window.dispatchEvent(new Event("pageshow"));
     });
 
-    expect(markThreadRead.mutate).toHaveBeenCalledTimes(2);
+    expect(markThreadRead.mutateAsync).toHaveBeenCalledTimes(2);
   });
 
   it("does not immediately undo marking the visible thread unread", () => {
@@ -145,11 +149,11 @@ describe("useThreadReadTracking", () => {
       { initialProps },
     );
 
-    expect(markThreadRead.mutate).not.toHaveBeenCalled();
+    expect(markThreadRead.mutateAsync).not.toHaveBeenCalled();
 
     rerender({ lastReadAt: null });
 
-    expect(markThreadRead.mutate).not.toHaveBeenCalled();
+    expect(markThreadRead.mutateAsync).not.toHaveBeenCalled();
   });
 
   it("does not undo marking the visible thread unread after tab refocus", () => {
@@ -170,7 +174,7 @@ describe("useThreadReadTracking", () => {
     );
 
     rerender({ lastReadAt: null });
-    expect(markThreadRead.mutate).not.toHaveBeenCalled();
+    expect(markThreadRead.mutateAsync).not.toHaveBeenCalled();
 
     act(() => {
       setDocumentVisibilityState("hidden");
@@ -181,7 +185,7 @@ describe("useThreadReadTracking", () => {
       document.dispatchEvent(new Event("visibilitychange"));
     });
 
-    expect(markThreadRead.mutate).not.toHaveBeenCalled();
+    expect(markThreadRead.mutateAsync).not.toHaveBeenCalled();
   });
 
   it("marks a manually unread thread read when it is opened again", () => {
@@ -204,14 +208,13 @@ describe("useThreadReadTracking", () => {
 
     rerender({ thread: unreadThread });
 
-    expect(markThreadRead.mutate).toHaveBeenCalledTimes(1);
-    expect(markThreadRead.mutate).toHaveBeenLastCalledWith(
+    expect(markThreadRead.mutateAsync).toHaveBeenCalledTimes(1);
+    expect(markThreadRead.mutateAsync).toHaveBeenLastCalledWith(
       expect.objectContaining({ threadId: "thr_side_chat" }),
-      expect.objectContaining({ onError: expect.any(Function) }),
     );
   });
 
-  it("marks a previously auto-read thread read when reopened after manual unread", () => {
+  it("marks a previously auto-read thread read when reopened after manual unread", async () => {
     const markThreadRead = makeMarkThreadRead();
     type ReopenThreadProps = {
       lastReadAt: number | null;
@@ -236,19 +239,20 @@ describe("useThreadReadTracking", () => {
       { initialProps },
     );
 
-    expect(markThreadRead.mutate).toHaveBeenCalledTimes(1);
+    expect(markThreadRead.mutateAsync).toHaveBeenCalledTimes(1);
 
     rerender({ lastReadAt: 20, visible: true });
     rerender({ lastReadAt: null, visible: true });
-    expect(markThreadRead.mutate).toHaveBeenCalledTimes(1);
+    expect(markThreadRead.mutateAsync).toHaveBeenCalledTimes(1);
 
     rerender({ lastReadAt: null, visible: false });
+    await act(async () => {});
     rerender({ lastReadAt: null, visible: true });
 
-    expect(markThreadRead.mutate).toHaveBeenCalledTimes(2);
+    expect(markThreadRead.mutateAsync).toHaveBeenCalledTimes(2);
   });
 
-  it("cancels a pending read when switching threads and retries when reopened", () => {
+  it("cancels a pending read when switching threads and retries when reopened", async () => {
     const markThreadRead = makeMarkThreadRead();
     type ThreadProps = { thread: TestThread };
     const { rerender } = renderHook(
@@ -265,7 +269,7 @@ describe("useThreadReadTracking", () => {
       },
     );
 
-    const firstInput = markThreadRead.mutate.mock.calls[0]?.[0];
+    const firstInput = markThreadRead.mutateAsync.mock.calls[0]?.[0];
     expect(firstInput?.signal?.aborted).toBe(false);
 
     rerender({
@@ -277,6 +281,7 @@ describe("useThreadReadTracking", () => {
     });
 
     expect(firstInput?.signal?.aborted).toBe(true);
+    await act(async () => {});
 
     rerender({
       thread: {
@@ -286,10 +291,9 @@ describe("useThreadReadTracking", () => {
       },
     });
 
-    expect(markThreadRead.mutate).toHaveBeenCalledTimes(2);
-    expect(markThreadRead.mutate).toHaveBeenLastCalledWith(
+    expect(markThreadRead.mutateAsync).toHaveBeenCalledTimes(2);
+    expect(markThreadRead.mutateAsync).toHaveBeenLastCalledWith(
       expect.objectContaining({ threadId: "thr_first" }),
-      expect.objectContaining({ onError: expect.any(Function) }),
     );
   });
 });

--- a/apps/app/src/hooks/useThreadReadTracking.ts
+++ b/apps/app/src/hooks/useThreadReadTracking.ts
@@ -9,10 +9,10 @@ import {
 type ThreadReadTrackingState = ThreadReadState & Pick<Thread, "id">;
 
 interface MarkThreadReadMutation {
-  mutate: (
-    input: { signal?: AbortSignal; threadId: string },
-    options?: { onError?: () => void; onSettled?: () => void },
-  ) => void;
+  mutateAsync: (input: {
+    signal?: AbortSignal;
+    threadId: string;
+  }) => Promise<ThreadReadState>;
 }
 
 interface UseThreadReadTrackingParams {
@@ -41,6 +41,13 @@ export function useThreadReadTracking({
   const isVisible = isDocumentVisible();
 
   useEffect(() => {
+    const controllers = pendingReadControllersRef.current;
+    return () => {
+      for (const controller of controllers.values()) controller.abort();
+    };
+  }, []);
+
+  useEffect(() => {
     const previousSnapshot = previousSnapshotRef.current;
     const threadIsRead = thread ? isThreadRead(thread) : null;
     const currentSnapshot: ReadTrackingSnapshot = {
@@ -52,12 +59,8 @@ export function useThreadReadTracking({
     previousSnapshotRef.current = currentSnapshot;
 
     if (previousSnapshot?.threadId !== currentSnapshot.threadId) {
-      const previousMarker = previousSnapshot?.threadId
-        ? `${previousSnapshot.threadId}:${previousSnapshot.latestAttentionAt}`
-        : null;
-      if (previousMarker) {
-        pendingReadControllersRef.current.get(previousMarker)?.abort();
-        pendingReadControllersRef.current.delete(previousMarker);
+      for (const controller of pendingReadControllersRef.current.values()) {
+        controller.abort();
       }
     }
 
@@ -80,7 +83,6 @@ export function useThreadReadTracking({
 
     if (threadIsRead) {
       failedReadKeysRef.current.delete(marker);
-      pendingReadControllersRef.current.delete(marker);
       suppressedManualUnreadKeysRef.current.delete(marker);
       return;
     }
@@ -117,17 +119,15 @@ export function useThreadReadTracking({
     failedReadKeysRef.current.delete(marker);
     const controller = new AbortController();
     pendingReadControllersRef.current.set(marker, controller);
-    markThreadRead.mutate(
-      { signal: controller.signal, threadId: thread.id },
-      {
-        onError: () => {
+    void markThreadRead
+      .mutateAsync({ signal: controller.signal, threadId: thread.id })
+      .catch(() => {
+        failedReadKeysRef.current.add(marker);
+      })
+      .finally(() => {
+        if (pendingReadControllersRef.current.get(marker) === controller) {
           pendingReadControllersRef.current.delete(marker);
-          failedReadKeysRef.current.add(marker);
-        },
-        onSettled: () => {
-          pendingReadControllersRef.current.delete(marker);
-        },
-      },
-    );
+        }
+      });
   }, [isVisible, markThreadRead, thread, visibilityRevision]);
 }


### PR DESCRIPTION
## Human comments

## What was wrong

After opening a thread, the optimistic read update made it look read before its HTTP request finished. The read-tracking hook then discarded the pending request's controller. Switching A → B → A could leave the original request stuck without cancellation or a replacement; unmount also left requests running. This completes the recovery behavior introduced in #3542.

## What changed

Keep pending read controllers until the mutation promise finishes, and cancel all outstanding reads on thread changes and unmount. Use the mutation promise for completion tracking so cleanup survives observer changes. On failure, roll back only the read timestamp that still matches the request's optimistic update, preserving newer manual-unread actions, thread fields, and sibling list/sidebar data.

No public API, CLI, daemon protocol, or database changes.

| Before | After |
| --- | --- |
| ![Before recovery: the test-only proxy is holding A's read request](https://raw.githubusercontent.com/get-bb/bb/038acba82692390e2da7dffa7afda4ac231af615/before.png) | ![After recovery: returning from B to A saved a fresh read](https://raw.githubusercontent.com/get-bb/bb/038acba82692390e2da7dffa7afda4ac231af615/after.png) |

These paired full-app screenshots are a temporal before/after on pushed head `855bc0a0aa`: the left capture is immediately before the A → B → A recovery flow while a test-only proxy holds A's first read; the right capture is after returning to A and verifying a fresh read was persisted. The overlay is test-only and the underlying app is the production build.

## How you verified

- New integrated navigation and unmount regressions fail against the original hook and pass with the fix. Coverage includes StrictMode, rapid return before cancellation finishes, unmount/remount, manual unread, newer attention, and cache preservation.
- `pnpm exec turbo run test --filter=@bb/app -- useThreadReadTracking thread-state-cache-owner.test thread-state-mutations.test EmbeddedThreadChat.test` — 51 tests passed.
- `pnpm exec turbo run typecheck build --filter=@bb/app` — passed.
- Browser source-fixture checks passed on desktop and exact 390×844 touch emulation in light/dark themes, including successful reads, failed-read recovery, manual unread, and new attention.
- The isolated full app plus source CLI and a test-only fetch-hold proxy reproduced the pending request. A stayed unread on the server while held; A → B → A cancelled it and persisted a replacement read, verified through the CLI and the paired screenshots above.
- Full-app compact/embedded and Safari were not exercised.

> AGENT GENERATED
