### PR TITLE
Keep compact machine progress within its row

### DIFF
--- a/apps/app/src/components/settings/MachinesSettingsSection.tsx
+++ b/apps/app/src/components/settings/MachinesSettingsSection.tsx
@@ -178,9 +178,7 @@ export function MachineRowContent({
               <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-subtle-foreground/75">
                 <span className="inline-flex min-w-0 items-center gap-1.5">
                   <MachineStatusDot tone={machineStatusTone(host)} />
-                  <span className="min-w-0 wrap-anywhere">
-                    {connectionLabel}
-                  </span>
+                  <span className="min-w-0 truncate">{connectionLabel}</span>
                 </span>
                 {platformLabel === null ? null : (
                   <span className="truncate">{platformLabel}</span>

--- a/apps/app/src/components/settings/MachinesSettingsSection.tsx
+++ b/apps/app/src/components/settings/MachinesSettingsSection.tsx
@@ -176,9 +176,11 @@ export function MachineRowContent({
                 ) : null}
               </div>
               <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-subtle-foreground/75">
-                <span className="inline-flex shrink-0 items-center gap-1.5">
+                <span className="inline-flex min-w-0 items-center gap-1.5">
                   <MachineStatusDot tone={machineStatusTone(host)} />
-                  {connectionLabel}
+                  <span className="min-w-0 wrap-anywhere">
+                    {connectionLabel}
+                  </span>
                 </span>
                 {platformLabel === null ? null : (
                   <span className="truncate">{platformLabel}</span>


### PR DESCRIPTION
## Human comments

## What was wrong

Machine lifecycle progress used a non-shrinking inline status wrapper. On a compact machine row, a normal pause message could extend past the 390px list and clip its text and controls off-screen.

## What changed

Allow the status group and its label to shrink, and truncate the progress text to one line with an ellipsis. The full status remains in the DOM and in the existing machine details view; desktop continues to show the ordinary message in full.

## Screenshots

| Before | After |
| --- | --- |
| ![Before: pause progress clips beyond the compact machine row](https://raw.githubusercontent.com/get-bb/bb/8bbbba88a21dc3ae97a532cdf349952806405f1e/before.png) | ![After: pause progress truncates to one line and keeps controls visible](https://raw.githubusercontent.com/get-bb/bb/8bbbba88a21dc3ae97a532cdf349952806405f1e/after.png) |
| 390×844 light theme: text and controls overflow the row. | 390×844 light theme: one-line ellipsis preserves the row and controls. |

The captures use the actual `MachinesSettingsSection` with synthetic machine data. The baseline is `2aa42d8861`; the final screenshot represents the pushed behavior at `7808146113` (the only post-capture source change was formatter-only JSX whitespace). Both immutable image URLs were checked byte-for-byte against the reviewed PNGs.

## How you verified

- Four browser cases passed at 390×844 and 1280×900 in light and dark themes: compact text stays on one line with an ellipsis, desktop keeps the full message, the status dot and controls remain visible, and the page stays width-bounded.
- Existing keyboard menu, Escape, Enter navigation, status, rename/remove/retry/suspend, and primary-machine regressions passed: 3 files, 19 tests.
- `pnpm exec turbo run build typecheck lint --filter=@bb/app --force` passed with 0 lint errors.
- Exact source formatting and `git diff --check origin/main...HEAD` passed.

> AGENT GENERATED
