### PR TITLE
Clean plugin workspaces after disabling from details

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -580,7 +580,7 @@ describe("PluginNavSidebarItems", () => {
       title: "Automations",
     },
   ])(
-    "replaces $title with New thread before disabling",
+    "replaces $title with New thread after disabling",
     async ({ pluginId, title }) => {
       let completeDisable: (response: Response) => void = () => {};
       const fetchMock = vi.fn<typeof fetch>(
@@ -618,12 +618,9 @@ describe("PluginNavSidebarItems", () => {
       expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
         `/plugins/${pluginId}/disable`,
       );
-      await waitFor(() =>
-        expect(screen.getByTestId("location-path").textContent).toBe("/"),
+      expect(screen.getByTestId("location-path").textContent).toBe(
+        `/plugins/${pluginId}/main`,
       );
-      expect(store.get(splitLayoutAtom)?.root).toMatchObject({
-        content: { kind: "new-thread" },
-      });
       expect(appToast.success).not.toHaveBeenCalled();
       await act(async () => {
         completeDisable(
@@ -635,6 +632,12 @@ describe("PluginNavSidebarItems", () => {
             },
           ),
         );
+      });
+      await waitFor(() =>
+        expect(screen.getByTestId("location-path").textContent).toBe("/"),
+      );
+      expect(store.get(splitLayoutAtom)?.root).toMatchObject({
+        content: { kind: "new-thread" },
       });
       expect(appToast.success).toHaveBeenCalledWith(`${title} disabled`);
       fireEvent.click(screen.getByRole("button", { name: "History back" }));
@@ -730,7 +733,7 @@ describe("PluginNavSidebarItems", () => {
         },
         focusedPaneId: "github",
       };
-      expect(layoutsAtDisable).toEqual([survivingLayout]);
+      expect(layoutsAtDisable[0]?.root.type).toBe("split");
       expect(store.get(splitLayoutAtom)).toEqual(survivingLayout);
       expect(store.get(maximizedPaneIdAtom)).toBeNull();
       expect(screen.getByTestId("location-path").textContent).toBe(

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -11,8 +11,7 @@ import {
   type ReactNode,
 } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { useAtom, useStore } from "jotai";
-import { flushSync } from "react-dom";
+import { useAtom } from "jotai";
 import { DndContext, type DragEndEvent } from "@dnd-kit/core";
 import {
   FilterHorizontalIcon,
@@ -54,8 +53,6 @@ import {
   AUTOMATIONS_PLUGIN_ID,
   getPluginDetailRoutePath,
   getPluginPanelRoutePath,
-  getPluginPanelRoutePluginId,
-  getRootComposeRoutePath,
 } from "@/lib/route-paths";
 import {
   usePluginNavPanelChrome,
@@ -86,16 +83,8 @@ import { useSidebarReorderDnd } from "@/components/sidebar/useSidebarReorderDnd"
 import type { SidebarSortableDragBindings } from "@/components/sidebar/sortableMotion";
 import { appToast } from "@/components/ui/app-toast";
 import { invalidatePluginList } from "@/hooks/cache-owners/plugin-cache-owner";
-import { setPluginEnabled } from "@/hooks/queries/plugin-settings-queries";
+import { useSetPluginEnabled } from "./useSetPluginEnabled";
 import { appQueryClient } from "@/lib/app-query-client";
-import { maximizedPaneIdAtom, splitLayoutAtom } from "@/lib/split-layout/atoms";
-import {
-  findPane,
-  listPanes,
-  removePane,
-  replacePaneContent,
-} from "@/lib/split-layout";
-import { focusedPaneRoute } from "@/views/thread-detail/splitThreadNavigation";
 import {
   pluginNavPanelOrderAtom,
   pluginNavVisiblePanelKeysAtom,
@@ -223,7 +212,7 @@ function PluginNavSidebarItemList({
 }) {
   const location = useLocation();
   const navigate = useNavigate();
-  const store = useStore();
+  const setEnabled = useSetPluginEnabled();
   const isCompactViewport = useIsCompactViewport();
   const splitActions = usePaneContentSplitActions();
   const [storedOrder, setStoredOrder] = useAtom(pluginNavPanelOrderAtom);
@@ -259,43 +248,7 @@ function PluginNavSidebarItemList({
       const pluginId = row.chrome.pluginId;
       setDisablePending(true);
       try {
-        const current = store.get(splitLayoutAtom);
-        let next = current;
-        if (next !== null) {
-          for (const pane of listPanes(next.root)) {
-            if (
-              pane.content.kind !== "plugin-panel" ||
-              pane.content.pluginId !== pluginId
-            )
-              continue;
-            next =
-              listPanes(next.root).length === 1
-                ? replacePaneContent(next, pane.paneId, { kind: "new-thread" })
-                : removePane(next, pane.paneId);
-          }
-        }
-        flushSync(() => {
-          if (next !== current) {
-            store.set(splitLayoutAtom, next);
-            const maximized = store.get(maximizedPaneIdAtom);
-            if (
-              maximized !== null &&
-              (next === null ||
-                listPanes(next.root).length < 2 ||
-                findPane(next.root, maximized) === null)
-            ) {
-              store.set(maximizedPaneIdAtom, null);
-            }
-          }
-          if (getPluginPanelRoutePluginId(location.pathname) === pluginId) {
-            onNavigate?.();
-            void navigate(
-              (next && focusedPaneRoute(next)) ?? getRootComposeRoutePath(),
-              { replace: true },
-            );
-          }
-        });
-        await setPluginEnabled(fetch, pluginId, false);
+        await setEnabled(pluginId, false, onNavigate);
         appToast.success(`${row.title} disabled`);
       } catch (error) {
         appToast.error(`Failed to disable ${row.title}`, {
@@ -306,7 +259,7 @@ function PluginNavSidebarItemList({
         setDisablePending(false);
       }
     },
-    [location.pathname, navigate, onNavigate, store],
+    [onNavigate, setEnabled],
   );
   const newLeadingKeys = useMemo(
     () =>

--- a/apps/app/src/components/plugin/PluginSettings.tsx
+++ b/apps/app/src/components/plugin/PluginSettings.tsx
@@ -1,3 +1,4 @@
+import { useSetPluginEnabled } from "@/components/plugin/useSetPluginEnabled";
 import { useEffect, useId, useState, type FocusEvent } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { appToast } from "@/components/ui/app-toast.js";
@@ -29,7 +30,6 @@ import {
   invalidatePluginList,
 } from "@/hooks/cache-owners/plugin-cache-owner";
 import {
-  setPluginEnabled,
   updatePluginSettings,
   usePluginList,
   usePluginSettingsView,
@@ -542,10 +542,10 @@ export function PluginSettingsPage({ pluginId }: { pluginId: string }) {
 function PluginSettingsContent({ plugin }: { plugin: PluginListItem }) {
   const queryClient = useQueryClient();
   const { settingsSections } = usePluginSlots();
+  const setEnabled = useSetPluginEnabled();
   const toggle = useMutation({
     meta: { showErrorToast: false },
-    mutationFn: (enabled: boolean) =>
-      setPluginEnabled(fetch, plugin.id, enabled),
+    mutationFn: (enabled: boolean) => setEnabled(plugin.id, enabled),
     onError: (error, enabled) => {
       appToast.error(
         `${enabled ? "Enabling" : "Disabling"} ${plugin.id} failed`,

--- a/apps/app/src/components/plugin/management/InstalledPluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/InstalledPluginsTab.tsx
@@ -1,3 +1,4 @@
+import { useSetPluginEnabled } from "@/components/plugin/useSetPluginEnabled";
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -11,10 +12,7 @@ import {
 import { ProvenancePill } from "@/components/tools/ProvenancePill";
 import { appToast } from "@/components/ui/app-toast.js";
 import { invalidatePluginList } from "@/hooks/cache-owners/plugin-cache-owner";
-import {
-  setPluginEnabled,
-  type PluginListItem,
-} from "@/hooks/queries/plugin-settings-queries";
+import type { PluginListItem } from "@/hooks/queries/plugin-settings-queries";
 import { pluginNeedsAttention } from "@/hooks/usePluginAttention";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
@@ -82,10 +80,10 @@ export function InstalledPluginRow({
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
+  const setEnabled = useSetPluginEnabled();
   const toggle = useMutation({
     meta: { showErrorToast: false },
-    mutationFn: (enabled: boolean) =>
-      setPluginEnabled(fetch, plugin.id, enabled),
+    mutationFn: (enabled: boolean) => setEnabled(plugin.id, enabled),
     onError: (error, enabled) => {
       appToast.error(
         `${enabled ? "Enabling" : "Disabling"} ${plugin.id} failed`,

--- a/apps/app/src/components/plugin/useSetPluginEnabled.ts
+++ b/apps/app/src/components/plugin/useSetPluginEnabled.ts
@@ -1,0 +1,74 @@
+import { useCallback, useLayoutEffect, useRef } from "react";
+import { flushSync } from "react-dom";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useStore } from "jotai";
+import { setPluginEnabled } from "@/hooks/queries/plugin-settings-queries";
+import { maximizedPaneIdAtom, splitLayoutAtom } from "@/lib/split-layout/atoms";
+import {
+  findPane,
+  listPanes,
+  removePane,
+  replacePaneContent,
+} from "@/lib/split-layout";
+import {
+  getPluginPanelRoutePluginId,
+  getRootComposeRoutePath,
+} from "@/lib/route-paths";
+import { focusedPaneRoute } from "@/views/thread-detail/splitThreadNavigation";
+
+export function useSetPluginEnabled() {
+  const store = useStore();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const currentLocation = useRef(location);
+  useLayoutEffect(() => {
+    currentLocation.current = location;
+  }, [location]);
+
+  return useCallback(
+    async (pluginId: string, enabled: boolean, onNavigate?: () => void) => {
+      await setPluginEnabled(fetch, pluginId, enabled);
+      if (enabled) return;
+      const current = store.get(splitLayoutAtom);
+      let next = current;
+      if (next !== null) {
+        for (const pane of listPanes(next.root)) {
+          if (
+            pane.content.kind !== "plugin-panel" ||
+            pane.content.pluginId !== pluginId
+          )
+            continue;
+          next =
+            listPanes(next.root).length === 1
+              ? replacePaneContent(next, pane.paneId, { kind: "new-thread" })
+              : removePane(next, pane.paneId);
+        }
+      }
+      flushSync(() => {
+        if (next !== current) {
+          store.set(splitLayoutAtom, next);
+          const maximized = store.get(maximizedPaneIdAtom);
+          if (
+            maximized !== null &&
+            (next === null ||
+              listPanes(next.root).length < 2 ||
+              findPane(next.root, maximized) === null)
+          ) {
+            store.set(maximizedPaneIdAtom, null);
+          }
+        }
+        if (
+          getPluginPanelRoutePluginId(currentLocation.current.pathname) ===
+          pluginId
+        ) {
+          onNavigate?.();
+          void navigate(
+            (next && focusedPaneRoute(next)) ?? getRootComposeRoutePath(),
+            { replace: true },
+          );
+        }
+      });
+    },
+    [navigate, store],
+  );
+}

--- a/apps/app/src/views/PluginPanelView.tsx
+++ b/apps/app/src/views/PluginPanelView.tsx
@@ -30,10 +30,14 @@ export function PluginPanelView(props: PluginPanelViewProps = {}) {
 
   if (panel === null) {
     if (!pluginsSettled) {
-      return <PageShell contentClassName="pt-4 md:pt-5">{null}</PageShell>;
+      return (
+        <PageShell contentClassName="pt-[calc(var(--bb-app-chrome-row-height)+1rem)] md:pt-[calc(var(--bb-app-chrome-row-height)+1.25rem)]">
+          {null}
+        </PageShell>
+      );
     }
     return (
-      <PageShell contentClassName="pt-4 md:pt-5">
+      <PageShell contentClassName="pt-[calc(var(--bb-app-chrome-row-height)+1rem)] md:pt-[calc(var(--bb-app-chrome-row-height)+1.25rem)]">
         <EmptyStatePanel className="rounded-lg p-6 text-sm">
           This plugin panel is not available. The plugin may have been disabled
           or removed.

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
 
+import { createStore, Provider } from "jotai";
+import { splitLayoutAtom, maximizedPaneIdAtom } from "@/lib/split-layout/atoms";
 import type { ReactNode } from "react";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -42,6 +45,7 @@ import type { PluginCatalogSearchEntry } from "@/hooks/queries/plugin-catalog-qu
 import { pluginSourceQueryKey } from "@/hooks/queries/query-keys";
 import type { PluginFrontendDiagnostic } from "@/lib/plugin-frontend";
 import {
+  makeInstalledPlugin,
   makePluginListItem,
   makePluginRegistrationSet,
 } from "@/test/fixtures/plugins";
@@ -1767,4 +1771,101 @@ describe("PluginDetail capability inventory", () => {
       expect(screen.getByText(label)).toBeTruthy();
     }
   });
+});
+
+describe("detail disable workspace cleanup", () => {
+  it.each([false, true])(
+    "preserves the workspace until disable settles (failure=%s)",
+    async (fails) => {
+      const store = createStore();
+      const layout = {
+        root: {
+          type: "pane" as const,
+          paneId: "github",
+          content: {
+            kind: "plugin-panel" as const,
+            pluginId: "github",
+            panelPath: "main",
+            subPath: "",
+          },
+        },
+        focusedPaneId: "github",
+      };
+      store.set(splitLayoutAtom, layout);
+      store.set(maximizedPaneIdAtom, "github");
+      let complete: ((response: Response) => void) | undefined;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL) => {
+          const url = String(input);
+          if (url.includes("/github/disable"))
+            return new Promise<Response>((resolve) => {
+              complete = resolve;
+            });
+          if (url === "/api/v1/plugins")
+            return Response.json({
+              plugins: [makeInstalledPlugin({ id: "github", name: "GitHub" })],
+            });
+          if (url.includes("plugin-catalog/search"))
+            return Response.json({ results: [], collections: [] });
+          return Response.json({ error: "not found" }, { status: 404 });
+        }),
+      );
+      const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+      render(
+        <QueryClientWrapper>
+          <Provider store={store}>
+            <MemoryRouter initialEntries={["/skills", "/plugins/github/main"]}>
+              <TooltipProvider>
+                <PluginDetailPaneView pluginId="github" />
+              </TooltipProvider>
+              <LocationProbe />
+              <HistoryBackButton />
+            </MemoryRouter>
+          </Provider>
+        </QueryClientWrapper>,
+      );
+      fireEvent.click(
+        await screen.findByRole("switch", { name: "Disable GitHub" }),
+      );
+      await waitFor(() =>
+        expect(
+          screen
+            .getByRole("switch", { name: "Disable GitHub" })
+            .hasAttribute("disabled"),
+        ).toBe(true),
+      );
+      await waitFor(() => expect(complete).toBeDefined());
+      expect(store.get(splitLayoutAtom)).toEqual(layout);
+      await act(async () =>
+        complete?.(
+          fails
+            ? Response.json({ error: "denied" }, { status: 500 })
+            : Response.json({
+                ok: true,
+                plugin: makeInstalledPlugin({
+                  id: "github",
+                  enabled: false,
+                  status: "disabled",
+                }),
+              }),
+        ),
+      );
+      if (fails) {
+        expect(store.get(splitLayoutAtom)).toEqual(layout);
+        expect(store.get(maximizedPaneIdAtom)).toBe("github");
+        expect(screen.getByTestId("route-path").textContent).toBe(
+          "/plugins/github/main",
+        );
+      } else {
+        expect(store.get(splitLayoutAtom)?.root).toMatchObject({
+          content: { kind: "new-thread" },
+        });
+        expect(store.get(maximizedPaneIdAtom)).toBeNull();
+        expect(screen.getByTestId("route-path").textContent).toBe("/");
+        fireEvent.click(screen.getByRole("button", { name: "Browser back" }));
+        expect(screen.getByTestId("route-path").textContent).toBe("/skills");
+      }
+    },
+  );
 });

--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -1,3 +1,4 @@
+import { useSetPluginEnabled } from "@/components/plugin/useSetPluginEnabled";
 import {
   Suspense,
   useCallback,
@@ -39,7 +40,6 @@ import {
 } from "@/hooks/queries/plugin-catalog-queries";
 import {
   removePlugin,
-  setPluginEnabled,
   usePluginList,
   type PluginListItem,
 } from "@/hooks/queries/plugin-settings-queries";
@@ -156,12 +156,13 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
       (plugin) => pluginIsLocalSource(plugin) && plugin.rootDir !== null,
     ),
   });
+  const setEnabled = useSetPluginEnabled();
   const pluginToggle = useMutation({
     meta: { showErrorToast: false },
     mutationFn: async (plugin: PluginListItem) => {
       const action = plugin.enabled ? "disable" : "enable";
       try {
-        await setPluginEnabled(fetch, plugin.id, !plugin.enabled);
+        await setEnabled(plugin.id, !plugin.enabled);
       } catch {
         throw new Error(`Failed to ${action} plugin`);
       }


### PR DESCRIPTION
## Human comments

## What was wrong

The plugin-details toggle updated enablement directly, bypassing the workspace cleanup used by the sidebar. Disabling a plugin from its details therefore left that plugin's workspace open on an unavailable-panel message. On compact screens, that fallback message also began underneath the sidebar trigger.

## What changed

- Centralized app-side plugin enable/disable behavior in `useSetPluginEnabled` and routed all four callers through it.
- After a successful disable, closes matching plugin workspaces while preserving unrelated panes and navigation behavior; rejected requests leave the workspace intact.
- Added compact spacing above the unavailable-plugin fallback so it clears the sidebar trigger.
- No server, SDK, CLI, schema, or daemon protocol changes.

## Before / after

| Scenario | Before | After |
| --- | --- | --- |
| Disable from plugin details (390×844, dark) | The disabled plugin workspace remains open on an unavailable-panel message.<br><br>![Before: stale unavailable plugin workspace](https://raw.githubusercontent.com/get-bb/bb/5472297844f27491f93b234edd34de065bcb48e6/.github/pr-evidence/thr_wfbdgxv8ii/compact-before.png) | The matching workspace closes and BB selects New thread when no other pane is available.<br><br>![After: plugin workspace closed](https://raw.githubusercontent.com/get-bb/bb/5472297844f27491f93b234edd34de065bcb48e6/.github/pr-evidence/thr_wfbdgxv8ii/compact-disable-fixed.png) |
| Compact unavailable state | The fallback begins beneath the sidebar control.<br><br>![Before: fallback overlaps sidebar control](https://raw.githubusercontent.com/get-bb/bb/5472297844f27491f93b234edd34de065bcb48e6/.github/pr-evidence/thr_wfbdgxv8ii/compact-before.png) | The fallback begins below the control with clear spacing.<br><br>![After: fallback clears sidebar control](https://raw.githubusercontent.com/get-bb/bb/5472297844f27491f93b234edd34de065bcb48e6/.github/pr-evidence/thr_wfbdgxv8ii/compact-spacing-fixed.png) |

Screenshots were captured from the real worktree app at the final pushed head. The before state was reproduced by restoring the prior direct details mutation; the after states use the final implementation.

## How you verified

- 155 focused app tests passed, including a regression that fails with the old details caller and passes with the shared hook.
- `pnpm exec turbo run typecheck --filter=@bb/app`
- Production worktree build passed.
- Real Chromium verification passed in desktop/light and 390×844 compact/dark modes; successful disable closed the workspace, failed disable retained it, and the compact fallback cleared the sidebar trigger.
- `git diff --check origin/main...HEAD`

> AGENT GENERATED
