### PR TITLE
Fix environment picker icon alignment and spacing without resizing

### DIFF
--- a/apps/app/.ladle/story-fixtures.ts
+++ b/apps/app/.ladle/story-fixtures.ts
@@ -349,7 +349,7 @@ export const STORY_ENVIRONMENT_PROVIDERS: readonly SystemEnvironmentProvider[] =
       id: "git-worktree",
       displayName: "Worktree",
       description: "Create an isolated Git worktree.",
-      icon: "GitBranch",
+      icon: "FolderGit",
       logoUrl: null,
       pluginId: "environment-git-worktree",
       acceptsEmptyInputs: true,

--- a/apps/app/src/components/pickers/EnvironmentPicker.stories.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.stories.tsx
@@ -1,5 +1,8 @@
 import type { ProjectSource } from "@bb/domain";
+import type { SystemEnvironmentProvider } from "@bb/server-contract";
+import modalLogoUrl from "../../../../../plugins/environment-modal-sandbox/modal-logo.svg?url";
 import { EnvironmentPickerUI } from "./EnvironmentPicker";
+import { ProjectSelector } from "./ProjectSelector";
 import { StoryCard, StoryRow } from "../../../.ladle/story-card";
 import {
   HOST_IDS,
@@ -239,5 +242,63 @@ export function ManyMachines() {
       defaultOpen
       modal={false}
     />
+  );
+}
+
+const modalComposition: SystemEnvironmentProvider = {
+  machineProviderId: "modal-sandbox",
+  id: "modal-composition",
+  displayName: "Modal Sandbox",
+  description: "Create a project checkout in a new Modal sandbox.",
+  icon: "Box",
+  logoUrl: modalLogoUrl,
+  pluginId: "environment-modal-sandbox",
+  acceptsEmptyInputs: true,
+  machineAvailability: {},
+  availability: null,
+  requires: {
+    projectCheckout: false,
+    gitCheckout: false,
+    gitRemote: true,
+    projectless: false,
+  },
+  inputs: null,
+};
+
+export function IconAlignment() {
+  return (
+    <StoryCard>
+      <StoryRow label="Project selector reference">
+        <ProjectSelector
+          projects={[{ id: "proj_demo", name: "bb" }]}
+          value="proj_demo"
+          onChange={noop}
+        />
+      </StoryRow>
+      {[
+        ["Persistent host · checkout", "project-checkout"],
+        ["Persistent host · worktree", "git-worktree"],
+        ["Modal sandbox", modalComposition.id],
+      ].map(([label, providerId]) => (
+        <StoryRow key={providerId} label={label}>
+          <EnvironmentPickerUI
+            value={`provider:${providerId}`}
+            sources={machineSources}
+            host={machineHosts[0] ?? null}
+            isLocal={false}
+            providers={[...STORY_ENVIRONMENT_PROVIDERS, modalComposition]}
+            selectedProviderHostId={HOST_IDS.local}
+            onSelectProvider={noop}
+            machines={{
+              hosts: machineHosts,
+              localDaemonHostId: null,
+              primaryHostId: HOST_IDS.local,
+            }}
+            muted
+            modal={false}
+          />
+        </StoryRow>
+      ))}
+    </StoryCard>
   );
 }

--- a/apps/app/src/components/plugin/ProviderIcon.tsx
+++ b/apps/app/src/components/plugin/ProviderIcon.tsx
@@ -94,7 +94,10 @@ export function ProviderIcon({
   const CustomIcon = slot?.icon;
   return (
     <span
-      className={cn("inline-flex size-6 shrink-0", className)}
+      className={cn(
+        "inline-flex size-6 min-h-max min-w-max shrink-0 items-center justify-center",
+        className,
+      )}
       style={
         tint != null &&
         isPresentationTintColor(tint.light) &&


### PR DESCRIPTION
## Human comments

## What was wrong

The environment picker placed a 16px SVG inside a 14px provider-icon wrapper. The graphic overflowed the space reserved for it, sitting low and crowding the label. The project selector centered its icon directly and did not have this mismatch.

## What changed

Center provider-icon contents and let the wrapper grow to its contents' intrinsic minimum dimensions. This preserves the existing icon sizes while reserving their full footprint. Add an Environment Picker / Icon Alignment gallery story covering persistent-host checkout, worktree, and the Modal logo alongside the project selector, and update the worktree fixture to use its production FolderGit icon.

## How you verified

- Browser measurements in the component gallery: checkout/worktree remain 16px, Modal remains 14px; all have zero vertical offset and the same 4px icon-to-label gap as the project selector. Before/after screenshots were reviewed.
- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/plugin/ProviderIcon.test.tsx src/components/plugin/EnvironmentProviderIcon.test.tsx src/components/pickers/EnvironmentPicker.test.tsx` — 39 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `pnpm start:worktree --dryrun` and `pnpm start:worktree` — built and started successfully; server and daemon health checks passed.

> AGENT GENERATED
