### PR TITLE
Restore plain machine headers in environment picker

### DIFF
--- a/apps/app/src/components/pickers/EnvironmentPicker.test.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.test.tsx
@@ -615,7 +615,7 @@ describe("EnvironmentPickerUI multi-machine menu", () => {
       screen
         .getByText("MacBook Pro")
         .parentElement?.querySelector('[data-icon="Laptop"]'),
-    ).not.toBeNull();
+    ).toBeNull();
 
     const checkoutItems = screen.getAllByRole("menuitem", {
       name: /Project checkout/u,

--- a/apps/app/src/components/pickers/EnvironmentPicker.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.tsx
@@ -41,7 +41,6 @@ import {
 } from "./environment-picker-value";
 import { selectHosts } from "@/hooks/queries/host-queries";
 import { providerInputsControlRequired } from "./environment-provider-inputs";
-import { MachineLabel } from "@/components/machines/MachineLabel";
 
 interface SelectedEnvironment {
   modeLabel: string;
@@ -619,7 +618,7 @@ function MachineSection({
       <DropdownMenuLabel className="min-w-0 text-muted-foreground">
         <span className="flex items-center gap-1.5">
           <MachineStatusDot connected={connected} />
-          <MachineLabel host={host} iconClassName="size-3" />
+          <span className="min-w-0 truncate">{host.name}</span>
           {isThisMachine ? (
             <span className={MACHINE_BADGE_CLASS_NAME}>this machine</span>
           ) : null}


### PR DESCRIPTION
## Human comments

## What was wrong

#3274 replaced plain machine names in the environment picker headers with `MachineLabel`, adding a tiny laptop icon beside every machine name, including servers and desktop machines.

## What changed

Restore the previous status-dot-and-name header markup. Preserve name truncation and the conditional “this machine” badge. Update the existing picker test to assert that headers contain no laptop icon.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- EnvironmentPicker.test.tsx` — all 31 tests passed, including the “this machine” badge assertion.
- Captured and visually inspected the actual picker in Ladle with fixture machines, both with and without local-daemon detection. Headers have no laptop icons; the local fixture shows the badge. Screenshot animations were disabled for stable captures.
- `git diff --check` passed.

> AGENT GENERATED
