### PR TITLE
Keep Markdown footnote links inside the preview

### DIFF
--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -8,7 +8,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { MarkdownPreview } from "./markdown-preview";
 import {
   MarkdownLocalFileContextMenuContext,
@@ -432,6 +432,36 @@ describe("MarkdownPreview", () => {
     expect(link.getAttribute("href")).toBe(
       `${window.location.protocol}//${window.location.hostname}:5173/demo`,
     );
+  });
+
+  it("scrolls footnote links within the preview instead of opening a new window", () => {
+    const scrollIntoView = vi.fn();
+    const originalScrollIntoView = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = scrollIntoView;
+    onTestFinished(() => {
+      Element.prototype.scrollIntoView = originalScrollIntoView;
+    });
+    const onOpenLink = vi.fn(() => true);
+    const content =
+      "Enrollment fell.[^ode]\n\n[^ode]: Oregon Department of Education.";
+
+    render(<MarkdownPreview content={content} linkRouting={{ onOpenLink }} />);
+    const { container: otherPreview } = render(
+      <MarkdownPreview content={content} />,
+    );
+
+    const [reference] = screen.getAllByRole("link", { name: "1" });
+    if (reference === undefined) throw new Error("missing footnote reference");
+    expect(reference.getAttribute("target")).toBeNull();
+
+    const notPrevented = fireEvent.click(reference);
+
+    expect(notPrevented).toBe(false);
+    expect(onOpenLink).not.toHaveBeenCalled();
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    const scrolledTo = scrollIntoView.mock.contexts[0] as Element;
+    expect(scrolledTo.id).toBe("user-content-fn-ode");
+    expect(otherPreview.contains(scrolledTo)).toBe(false);
   });
 
   it("renders inline LaTeX math with KaTeX", async () => {

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -590,7 +590,20 @@ function MarkdownAnchor({
     localFileLink !== null && getContextMenuItems !== null
       ? getContextMenuItems(localFileLink)
       : null;
+  const inPageFragment = rewrittenHref?.startsWith("#")
+    ? rewrittenHref.slice(1)
+    : null;
   const handleAnchorClick = (event: MarkdownAnchorEvent) => {
+    if (inPageFragment !== null) {
+      event.preventDefault();
+      const root = event.currentTarget.closest("[data-markdown-preview]");
+      const destination = Array.from(root?.querySelectorAll("[id]") ?? []).find(
+        (element) => element.id === inPageFragment,
+      );
+      destination?.scrollIntoView({ block: "start" });
+      return;
+    }
+
     if (localFileLink && onOpenLocalFileLink) {
       if (onOpenLocalFileLink(localFileLink)) {
         event.preventDefault();
@@ -619,8 +632,8 @@ function MarkdownAnchor({
       className={cn(
         "break-words [overflow-wrap:anywhere] underline underline-offset-2",
       )}
-      target="_blank"
-      rel="noopener noreferrer"
+      target={inPageFragment === null ? "_blank" : undefined}
+      rel={inPageFragment === null ? "noopener noreferrer" : undefined}
       onClick={handleAnchorClick}
     >
       {children}
@@ -859,8 +872,12 @@ function MarkdownOrderedList({
   );
 }
 
-function MarkdownListItem({ children }: MarkdownListItemProps) {
-  return <li className="mb-1 text-foreground">{children}</li>;
+function MarkdownListItem({ children, id }: MarkdownListItemProps) {
+  return (
+    <li id={id} className="mb-1 text-foreground">
+      {children}
+    </li>
+  );
 }
 
 function MarkdownBlockquote({ children }: MarkdownBlockquoteProps) {


### PR DESCRIPTION
## What was wrong

Markdown footnote references use `#user-content-fn-…` links, but `MarkdownAnchor` applied `target="_blank"` to every link. Fragment links therefore opened the app URL with a hash in a new browser window instead of staying in the preview. `MarkdownListItem` also dropped the footnote `id`, leaving the reference with no rendered destination.

## What changed

`apps/app/src/components/ui/markdown-preview.tsx` now handles `#` links as in-preview navigation: it prevents default navigation, finds the matching id inside the closest `[data-markdown-preview]`, and scrolls it into view at `block: "start"`. It does not add `target` or `rel` to fragment links. Broken fragments also remain in the preview rather than opening a browser window.

`MarkdownListItem` now forwards `id` to its `<li>`, preserving the footnote destination without changing the existing handling of other list-item props. Scoping the lookup to the preview keeps footnote ids from colliding when the same Markdown renders in more than one preview at once. #3395 remains out of scope: it concerns external links in the file preview and is not fixed here.

<details>
<summary>Implementation details</summary>

The destination search iterates `[id]` elements instead of building a CSS id selector, so ids need no CSS escaping. Back-reference links use the same path, though the new test covers only the forward footnote reference. A sticky header in a scroll container can still cover a destination because scrolling uses `block: "start"`.

</details>

## How you verified

`apps/app/src/components/ui/markdown-preview.test.tsx` adds a two-preview footnote test. It confirms the first preview's reference has no `target`, prevents its default action, does not call `linkRouting.onOpenLink`, and calls `scrollIntoView` once on `#user-content-fn-ode` in that preview only. The test failed before the change because `_blank` was present, then still failed after the anchor change alone because the dropped list-item id left `scrollIntoView` uncalled. It passes after both changes.

- `pnpm exec turbo run typecheck --filter=@bb/app` passes.
- `pnpm exec turbo run test --filter=@bb/app` runs 4,448 passing tests, but `src/components/thread/terminal/ThreadTerminalView.test.ts` fails while importing `@xterm/xterm` `Platform.ts` with `Cannot read properties of undefined (reading 'indexOf')`. The same failure occurs with this diff reverted, so it is pre-existing and unrelated.
- Prettier check passes on both changed files.

The behavior has not been checked in the running desktop app or iOS Safari; verification is limited to jsdom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> AGENT GENERATED
