### PR TITLE
Preserve bundled npm dependencies in desktop packages

### DIFF
--- a/apps/desktop/electron-builder.config.json
+++ b/apps/desktop/electron-builder.config.json
@@ -21,6 +21,11 @@
       "to": "node_modules/bb-app/server/dist/app-scaffold-template",
       "filter": ["**/*"]
     },
+    {
+      "from": "node_modules/bb-app/node_modules/npm/node_modules",
+      "to": "node_modules/npm/node_modules",
+      "filter": ["**/*"]
+    },
     "package.json",
     "!**/*.map"
   ],

--- a/apps/desktop/scripts/prepare-native-modules.cjs
+++ b/apps/desktop/scripts/prepare-native-modules.cjs
@@ -265,6 +265,18 @@ async function afterPack(context) {
     electronVersion: resolveElectronVersion(),
     platform: context.electronPlatformName ?? process.platform,
   });
+  const { smokePackagedNpm } = await import("./smoke-packaged-npm.mjs");
+  const appBinary =
+    context.electronPlatformName === "darwin"
+      ? path.join(
+          context.appOutDir,
+          `${context.packager.appInfo.productFilename}.app`,
+          "Contents",
+          "MacOS",
+          context.packager.appInfo.productFilename,
+        )
+      : path.join(context.appOutDir, context.packager.executableName);
+  await smokePackagedNpm(appBinary);
 }
 
 function parseStandaloneArguments(argv) {

--- a/apps/desktop/scripts/smoke-packaged-app.mjs
+++ b/apps/desktop/scripts/smoke-packaged-app.mjs
@@ -12,6 +12,7 @@ import {
 } from "./desktop-release-channel.mjs";
 import { createPackagedAppLaunchArguments } from "./packaged-app-launch.mjs";
 import { resolvePackagedAppBinary } from "./packaged-app-paths.mjs";
+import { smokePackagedNpm } from "./smoke-packaged-npm.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const desktopPackageRoot = resolve(scriptDirectory, "..");
@@ -317,6 +318,7 @@ async function smokePackagedApp() {
     productName: releaseConfig.applicationName,
     releaseDir,
   });
+  await smokePackagedNpm(appBinary);
   const smokeRoot = await mkdtemp(join(tmpdir(), "bb-desktop-packaged-smoke-"));
   const dataDir = join(smokeRoot, "data");
   const userDataDir = join(smokeRoot, "user-data");

--- a/apps/desktop/scripts/smoke-packaged-npm.mjs
+++ b/apps/desktop/scripts/smoke-packaged-npm.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+
+export async function smokePackagedNpm(appBinary) {
+  const resourcesDir =
+    process.platform === "darwin"
+      ? join(dirname(appBinary), "..", "Resources")
+      : join(dirname(appBinary), "resources");
+  const requireFromApp = createRequire(
+    join(
+      resourcesDir,
+      "app.asar.unpacked",
+      "node_modules",
+      "bb-app",
+      "package.json",
+    ),
+  );
+  const npmManifest = requireFromApp.resolve("npm/package.json");
+  const npmCli = join(dirname(npmManifest), "bin", "npm-cli.js");
+  const { version } = JSON.parse(await readFile(npmManifest, "utf8"));
+  const fixture = await mkdtemp(join(tmpdir(), "bb-packaged-npm-smoke-"));
+  try {
+    const project = join(fixture, "project");
+    const dependency = join(fixture, "dependency");
+    await mkdir(project);
+    await mkdir(dependency);
+    await writeFile(
+      join(dependency, "package.json"),
+      JSON.stringify({
+        name: "bb-smoke-dependency",
+        version: "1.0.0",
+        main: "index.js",
+      }),
+    );
+    await writeFile(
+      join(dependency, "index.js"),
+      'module.exports = "packaged npm works";\n',
+    );
+    await writeFile(
+      join(project, "package.json"),
+      JSON.stringify({
+        name: "bb-packaged-npm-smoke",
+        version: "1.0.0",
+        private: true,
+        dependencies: { "bb-smoke-dependency": "file:../dependency" },
+        scripts: { preinstall: "exit 42" },
+      }),
+    );
+    const env = Object.fromEntries(
+      Object.entries(process.env).filter(
+        ([key]) =>
+          !/^npm_/i.test(key) && key !== "NODE_OPTIONS" && key !== "NODE_PATH",
+      ),
+    );
+    const options = {
+      cwd: project,
+      timeout: 30_000,
+      maxBuffer: 1024 * 1024,
+      env: {
+        ...env,
+        ELECTRON_RUN_AS_NODE: "1",
+        PATH: "",
+        npm_config_cache: join(fixture, "cache"),
+        npm_config_userconfig: join(fixture, "user-npmrc"),
+        npm_config_globalconfig: join(fixture, "global-npmrc"),
+        npm_config_update_notifier: "false",
+      },
+    };
+    const result = await run(appBinary, [npmCli, "--version"], options);
+    assert.equal(result.stdout.trim(), version);
+    await run(
+      appBinary,
+      [
+        npmCli,
+        "install",
+        "--offline",
+        "--install-links",
+        "--ignore-scripts",
+        "--omit=dev",
+        "--omit=optional",
+        "--no-audit",
+        "--no-fund",
+      ],
+      options,
+    );
+    const requireFromProject = createRequire(join(project, "package.json"));
+    assert.equal(
+      requireFromProject("bb-smoke-dependency"),
+      "packaged npm works",
+    );
+    console.log(
+      `Packaged npm ${version} installed a dependency with an empty PATH.`,
+    );
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+}

--- a/docs/debugging-and-qa.md
+++ b/docs/debugging-and-qa.md
@@ -333,6 +333,30 @@ argument. The bridge subprocess receives only its script path. The AppImage
 lifecycle smoke exercises this launch and verifies that its runtime mount
 survives closing the GUI.
 
+## Packaged Desktop npm
+
+Plugin dependency installs and build-tool downloads use the npm shipped with BB,
+running through Electron's Node runtime. npm ships its dependencies inside its
+own `node_modules`; pnpm's dependency listing does not expand that tree, and
+electron-builder's normal dependency copier skips nested `node_modules`.
+The desktop configuration copies that tree through a dedicated file set so it
+is included in the ASAR/unpacked output before signing.
+
+The `afterPack` hook checks npm before signing or publishing, and
+`smoke:packaged` repeats the check before opening the desktop window. It resolves npm
+from the packaged `bb-app`, checks its version, and installs a local dependency
+offline with an empty PATH, a fresh cache, and lifecycle scripts disabled.
+This exercises the final desktop artifact; the bb-app tarball smoke cannot
+detect files omitted by Electron packaging. All fixture data is temporary.
+
+To run just the npm check without opening a window:
+
+```bash
+node --input-type=module -e 'import { smokePackagedNpm } from "./apps/desktop/scripts/smoke-packaged-npm.mjs"; await smokePackagedNpm(process.argv[1]);' /absolute/path/to/bb.app/Contents/MacOS/bb
+```
+
+On Linux, pass the binary in `release/linux-unpacked/`.
+
 ## Prepared Worktree Restarts
 
 `pnpm start` and `pnpm start:worktree` always run Turbo-backed preparation before


### PR DESCRIPTION
## Human comments

## What was wrong

Desktop 0.43.0 switched plugin installs to bundled npm 11.16.0 in #3529, but the Electron artifact omitted npm's nested dependency tree. pnpm reports npm without child dependencies, while electron-builder's dependency copier excludes nested `node_modules`. The installed macOS app fails even on `npm --version` with exit 7 and `Cannot find module 'proc-log'`; 60 of npm's 65 direct dependencies cannot resolve. The existing npm check only covered the bb-app tarball, and desktop smoke only exercised the preload/window path.

## What changed

Copy npm's nested dependency tree through an explicit desktop file set, preserving it in ASAR/unpacked resources before signing. Run an offline install check through the packaged Electron executable with an empty PATH, a fresh npm cache/config, and lifecycle scripts disabled. Invoke the check in `afterPack` so packaging fails before signing or uploading artifacts, and repeat it in packaged desktop smoke. Document how to run the npm check without opening a window.

No server/daemon wire, SDK, CLI, or user configuration changes.

## How you verified

- Reproduced the exact exit-7 `proc-log` error using the installed 0.43.0 app's Electron executable and bundled npm.
- Built a real macOS arm64 desktop artifact using the pnpm collector and the updated file set. The `afterPack` check printed `Packaged npm 11.16.0 installed a dependency with an empty PATH.` Packaging completed successfully; the standalone check also passed.
- Built again with a temporary configuration removing only the new file set. The new `afterPack` check failed with `Cannot find module 'proc-log'`, stopping packaging before signing. Production source configuration was unchanged by this negative control.
- `pnpm exec turbo run build typecheck test --filter=@bb/desktop`: 52 tasks succeeded; 320 desktop tests passed, 1 skipped. The first sandboxed attempt aborted Electron startup; the desktop-enabled rerun passed.
- After the hook change, `pnpm exec turbo run test --filter=@bb/desktop -- --run test/electron-builder-config.test.ts`: 22 tests passed.
- Formatting and `git diff --check` passed.
- Local artifacts were unsigned and never published or installed. Linux execution and signed-release verification remain for CI. The full packaged GUI smoke was not rerun after the user asked to avoid more test windows; the npm check runs entirely in Node mode.

> AGENT GENERATED
