### PR TITLE
Preserve bundled npm dependencies in desktop artifacts

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -83,6 +83,43 @@ machines with no keychain identity (or with `CSC_IDENTITY_AUTO_DISCOVERY=false`,
 as CI sets for workflow-artifact-only builds), artifacts remain unsigned and
 macOS shows the normal Gatekeeper warning on first launch.
 
+For local verification without publishing, use
+`pnpm exec turbo run package --filter=@bb/desktop` on macOS, or
+`pnpm exec turbo run package:linux --filter=@bb/desktop` on Linux.
+
+npm's bundled dependencies are copied through an explicit `files` entry into
+`node_modules/npm/node_modules`, including nested dependency versions. pnpm's
+dependency listing omits this bundled tree, and electron-builder's dependency
+copier excludes nested `node_modules`. `asarUnpack` alone cannot preserve files
+that the collector never selected. The explicit file set enters both ASAR's
+file index and its unpacked resources before signing.
+
+Packaging runs an offline npm smoke check in `afterPack`, before signing or
+publishing. This requires a native target host (macOS arm64 or Linux x64).
+`smoke:packaged` repeats it against the resulting artifact. To run only npm
+verification without opening a desktop window:
+
+```bash
+pnpm exec turbo run smoke:packaged-npm --filter=@bb/desktop
+pnpm exec turbo run smoke:packaged-npm --filter=@bb/desktop -- /absolute/path/to/bb.app/Contents/MacOS/bb
+```
+
+On Linux, the optional argument is the executable inside `linux-unpacked/` or
+an extracted AppImage. The check resolves npm from packaged `bb-app`, audits
+required dependency edges and version ranges in npm's entire bundled tree using
+both CJS and ESM resolution, rejects paths outside packaged resources, imports npm's ESM display
+dependencies, and verifies its version. It then uses bundled Electron and npm
+to pack, install, and update a disposable plugin's dependency from 1.0.0 to
+2.0.0, verifying the lockfile and importing the plugin's ESM entry after each
+install. It uses the plugin install flags, an empty PATH, offline mode, a fresh
+HOME/cache/config, and disabled lifecycle scripts. No system Node/npm or user
+store is used by the child processes. It also hashes ASAR and unpacked resources
+before and after to reject bundle mutations. Fixtures are removed afterward.
+
+The bb-app tarball smoke covers a different packaging pipeline and cannot
+detect Electron artifact omissions. A source build or `npm --version` alone
+does not verify a desktop plugin dependency install.
+
 ### Linux (AppImage, x64)
 
 Linux packaging targets x64 glibc-based distributions. Install `python3`,
@@ -92,9 +129,9 @@ From the repo root, build an unpacked app, an AppImage distribution, or smoke
 test the current packaged output with:
 
 ```bash
-pnpm --filter @bb/desktop run package:linux
-pnpm --filter @bb/desktop run dist:linux
-pnpm --filter @bb/desktop run smoke:packaged
+pnpm exec turbo run package:linux --filter=@bb/desktop
+pnpm exec turbo run desktop:build:linux --filter=@bb/desktop
+pnpm exec turbo run smoke:packaged --filter=@bb/desktop
 ```
 
 Running an AppImage normally requires FUSE and, on some distributions, the

--- a/apps/desktop/electron-builder.config.json
+++ b/apps/desktop/electron-builder.config.json
@@ -21,6 +21,11 @@
       "to": "node_modules/bb-app/server/dist/app-scaffold-template",
       "filter": ["**/*"]
     },
+    {
+      "from": "node_modules/bb-app/node_modules/npm/node_modules",
+      "to": "node_modules/npm/node_modules",
+      "filter": ["**/*"]
+    },
     "package.json",
     "!**/*.map"
   ],

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,6 +22,7 @@
     "prepare-runtime": "pnpm exec turbo run build --filter=bb-app --output-logs=new-only",
     "smoke:appimage-lifecycle": "node scripts/smoke-linux-appimage-lifecycle.mjs",
     "smoke:packaged": "node scripts/smoke-packaged-app.mjs",
+    "smoke:packaged-npm": "node scripts/smoke-packaged-npm.mjs",
     "smoke:browser-cdp": "node scripts/smoke-browser-cdp.mjs",
     "start": "pnpm run package && node scripts/run-packaged-app.mjs",
     "start:linux": "pnpm run package:linux && node scripts/run-packaged-app.mjs",

--- a/apps/desktop/scripts/prepare-native-modules.cjs
+++ b/apps/desktop/scripts/prepare-native-modules.cjs
@@ -260,11 +260,29 @@ function resolveArchName(context) {
 }
 
 async function afterPack(context) {
+  const arch = resolveArchName(context);
+  const platform = context.electronPlatformName ?? process.platform;
+  if (platform !== process.platform || arch !== process.arch) {
+    throw new Error("Packaged npm verification requires a native target host");
+  }
   await preparePackagedNativeModules(context.appOutDir, {
-    arch: resolveArchName(context),
+    arch,
     electronVersion: resolveElectronVersion(),
-    platform: context.electronPlatformName ?? process.platform,
+    platform,
   });
+  const { smokePackagedNpm } = await import("./smoke-packaged-npm.mjs");
+  const productName = context.packager.appInfo.productFilename;
+  const appBinary =
+    platform === "darwin"
+      ? path.join(
+          context.appOutDir,
+          `${productName}.app`,
+          "Contents",
+          "MacOS",
+          productName,
+        )
+      : path.join(context.appOutDir, context.packager.executableName);
+  await smokePackagedNpm(appBinary);
 }
 
 function parseStandaloneArguments(argv) {

--- a/apps/desktop/scripts/smoke-packaged-app.mjs
+++ b/apps/desktop/scripts/smoke-packaged-app.mjs
@@ -12,6 +12,7 @@ import {
 } from "./desktop-release-channel.mjs";
 import { createPackagedAppLaunchArguments } from "./packaged-app-launch.mjs";
 import { resolvePackagedAppBinary } from "./packaged-app-paths.mjs";
+import { smokePackagedNpm } from "./smoke-packaged-npm.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const desktopPackageRoot = resolve(scriptDirectory, "..");
@@ -317,6 +318,7 @@ async function smokePackagedApp() {
     productName: releaseConfig.applicationName,
     releaseDir,
   });
+  await smokePackagedNpm(appBinary);
   const smokeRoot = await mkdtemp(join(tmpdir(), "bb-desktop-packaged-smoke-"));
   const dataDir = join(smokeRoot, "data");
   const userDataDir = join(smokeRoot, "user-data");

--- a/apps/desktop/scripts/smoke-packaged-npm.mjs
+++ b/apps/desktop/scripts/smoke-packaged-npm.mjs
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  readlink,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import {
+  createDesktopReleaseConfig,
+  resolveDesktopReleaseChannel,
+} from "./desktop-release-channel.mjs";
+import { resolvePackagedAppBinary } from "./packaged-app-paths.mjs";
+
+const run = promisify(execFile);
+
+async function hashPackagedResources(resources) {
+  const hash = createHash("sha256");
+  async function visit(file) {
+    const stat = await lstat(file);
+    hash.update(JSON.stringify([file, stat.mode]));
+    if (stat.isDirectory()) {
+      for (const name of (await readdir(file)).sort())
+        await visit(join(file, name));
+    } else {
+      hash.update(
+        stat.isSymbolicLink() ? await readlink(file) : await readFile(file),
+      );
+    }
+  }
+  await visit(join(resources, "app.asar"));
+  await visit(join(resources, "app.asar.unpacked"));
+  return hash.digest("hex");
+}
+
+async function auditDependencies(modulesRoot) {
+  const { createRequire } = await import("node:module");
+  const { readdir, readFile, realpath } = await import("node:fs/promises");
+  const { dirname, join, sep } = await import("node:path");
+  const { fileURLToPath, pathToFileURL } = await import("node:url");
+  const assert = (await import("node:assert/strict")).default;
+  assert.ok(process.versions.electron, "npm must run through bundled Electron");
+  const root = await realpath(modulesRoot);
+  async function insideArtifact(file) {
+    const resolved = await realpath(file);
+    assert.ok(
+      resolved.startsWith(root + sep),
+      `Dependency escaped artifact: ${resolved}`,
+    );
+    return resolved;
+  }
+  const fromApp = createRequire(join(root, "bb-app", "package.json"));
+  const manifestPath = await insideArtifact(
+    fromApp.resolve("npm/package.json"),
+  );
+  const npmRoot = dirname(manifestPath);
+  const npm = JSON.parse(await readFile(manifestPath, "utf8"));
+  const fromNpm = createRequire(manifestPath);
+  const semver = fromNpm(await insideArtifact(fromNpm.resolve("semver")));
+  const resolvedVersions = new Map();
+  async function dependencyVersion(entry, name) {
+    const key = `${entry}:${name}`;
+    if (resolvedVersions.has(key)) return resolvedVersions.get(key);
+    let directory = dirname(entry);
+    while (directory.startsWith(root + sep)) {
+      const manifest = await readFile(
+        join(directory, "package.json"),
+        "utf8",
+      ).catch((error) => {
+        if (error.code === "ENOENT") return "null";
+        throw error;
+      });
+      const parsed = JSON.parse(manifest);
+      if (parsed?.name === name) {
+        resolvedVersions.set(key, parsed.version);
+        return parsed.version;
+      }
+      directory = dirname(directory);
+    }
+    throw new Error(`No packaged manifest for ${name} at ${entry}`);
+  }
+  let packages = 0;
+  let resolutions = 0;
+  async function auditPackage(packageRoot) {
+    const manifestPath = join(packageRoot, "package.json");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    const require = createRequire(manifestPath);
+    for (const [name, range] of Object.entries(manifest.dependencies ?? {})) {
+      if (name in (manifest.optionalDependencies ?? {})) continue;
+      const cjs = await insideArtifact(require.resolve(name));
+      const esm = await insideArtifact(
+        fileURLToPath(
+          import.meta.resolve(name, pathToFileURL(manifestPath).href),
+        ),
+      );
+      for (const entry of new Set([cjs, esm])) {
+        const version = await dependencyVersion(entry, name);
+        assert.ok(
+          semver.satisfies(version, range),
+          `${manifest.name} requires ${name}@${range}, resolved ${version} at ${entry}`,
+        );
+      }
+      resolutions++;
+    }
+    packages++;
+    const nested = join(packageRoot, "node_modules");
+    const entries = await readdir(nested, { withFileTypes: true }).catch(
+      (error) => {
+        if (error.code === "ENOENT") return [];
+        throw error;
+      },
+    );
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue;
+      assert.ok(
+        entry.isDirectory(),
+        `Unexpected bundled dependency link: ${entry.name}`,
+      );
+      const child = join(nested, entry.name);
+      if (entry.name.startsWith("@")) {
+        for (const name of await readdir(child))
+          await auditPackage(join(child, name));
+      } else {
+        await auditPackage(child);
+      }
+    }
+  }
+  await auditPackage(npmRoot);
+  const chalkUrl = import.meta.resolve(
+    "chalk",
+    pathToFileURL(manifestPath).href,
+  );
+  const chalk = await import(chalkUrl);
+  assert.equal(typeof chalk.default, "function");
+  await import(pathToFileURL(join(npmRoot, "lib", "utils", "display.js")).href);
+  console.log(
+    JSON.stringify({
+      npmCli: join(npmRoot, "bin", "npm-cli.js"),
+      version: npm.version,
+      directDependencies: Object.keys(npm.dependencies).length,
+      packages,
+      resolutions,
+      electron: process.versions.electron,
+      node: process.versions.node,
+    }),
+  );
+}
+
+export async function smokePackagedNpm(appBinary) {
+  appBinary = resolve(appBinary);
+  const resources =
+    process.platform === "darwin"
+      ? resolve(dirname(appBinary), "..", "Resources")
+      : join(dirname(appBinary), "resources");
+  const fixture = await realpath(
+    await mkdtemp(join(tmpdir(), "bb-packaged-npm-smoke-")),
+  );
+  try {
+    const resourcesBefore = await hashPackagedResources(resources);
+    const plugin = join(fixture, "plugin");
+    const dependency = join(fixture, "dependency");
+    await mkdir(plugin);
+    await mkdir(dependency);
+    const options = {
+      cwd: fixture,
+      timeout: 60_000,
+      maxBuffer: 1024 * 1024,
+      env: {
+        ELECTRON_RUN_AS_NODE: "1",
+        PATH: "",
+        HOME: fixture,
+        TMPDIR: fixture,
+        npm_config_cache: join(fixture, "cache"),
+        npm_config_userconfig: join(fixture, "user-npmrc"),
+        npm_config_globalconfig: join(fixture, "global-npmrc"),
+        npm_config_update_notifier: "false",
+        npm_config_offline: "true",
+      },
+    };
+    const auditScript = join(fixture, "audit-dependencies.mjs");
+    await writeFile(
+      auditScript,
+      `await (${auditDependencies.toString()})(${JSON.stringify(join(resources, "app.asar.unpacked", "node_modules"))});\n`,
+    );
+    const audit = await run(
+      appBinary,
+      ["--experimental-import-meta-resolve", auditScript],
+      options,
+    );
+    const result = JSON.parse(audit.stdout);
+    assert.equal(typeof result.npmCli, "string");
+    assert.equal(typeof result.version, "string");
+    const npm = (...args) => run(appBinary, [result.npmCli, ...args], options);
+    assert.equal((await npm("--version")).stdout.trim(), result.version);
+    for (const version of ["1.0.0", "2.0.0"]) {
+      await writeFile(
+        join(dependency, "package.json"),
+        JSON.stringify({
+          name: "bb-smoke-dependency",
+          version,
+          type: "module",
+          exports: "./index.js",
+          scripts: { preinstall: "exit 42", postinstall: "exit 42" },
+        }),
+      );
+      await writeFile(
+        join(dependency, "index.js"),
+        `export default ${JSON.stringify(version)};\n`,
+      );
+      await npm(
+        "pack",
+        dependency,
+        "--pack-destination",
+        fixture,
+        "--ignore-scripts",
+      );
+      await writeFile(
+        join(plugin, "package.json"),
+        JSON.stringify({
+          name: "bb-plugin-packaged-npm-smoke",
+          version,
+          type: "module",
+          bb: {
+            name: "Packaged npm smoke",
+            description: "Disposable desktop dependency install fixture",
+            branding: { icon: "Zap" },
+            server: "./server.js",
+          },
+          dependencies: {
+            "bb-smoke-dependency": `file:../bb-smoke-dependency-${version}.tgz`,
+          },
+          scripts: { preinstall: "exit 42", postinstall: "exit 42" },
+        }),
+      );
+      await writeFile(
+        join(plugin, "server.js"),
+        'export { default as dependencyVersion } from "bb-smoke-dependency";\nexport default function plugin() {}\n',
+      );
+      await npm(
+        "install",
+        "--prefix",
+        plugin,
+        "--ignore-scripts",
+        "--omit=dev",
+        "--omit=optional",
+        "--no-audit",
+        "--no-fund",
+      );
+      const probe = await run(
+        appBinary,
+        [
+          "--input-type=module",
+          "--eval",
+          `import { dependencyVersion } from ${JSON.stringify(pathToFileURL(join(plugin, "server.js")).href)}; console.log(dependencyVersion);`,
+        ],
+        options,
+      );
+      assert.equal(probe.stdout.trim(), version);
+      const lock = JSON.parse(
+        await readFile(join(plugin, "package-lock.json"), "utf8"),
+      );
+      assert.ok(
+        lock.packages["node_modules/bb-smoke-dependency"],
+        JSON.stringify(lock),
+      );
+      assert.equal(
+        lock.packages["node_modules/bb-smoke-dependency"].version,
+        version,
+      );
+    }
+    assert.equal(
+      await hashPackagedResources(resources),
+      resourcesBefore,
+      "Plugin dependency install/update modified packaged resources",
+    );
+    console.log(
+      `Packaged npm ${result.version}: ${result.directDependencies} direct dependencies, ${result.packages} bundled packages, ${result.resolutions} CJS/ESM dependency edges; offline plugin dependency install/update passed with Electron ${result.electron} (Node ${result.node}) and empty PATH; packaged resources unchanged.`,
+    );
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  const releaseConfig = createDesktopReleaseConfig(
+    resolveDesktopReleaseChannel(process.env),
+  );
+  const appBinary =
+    process.argv[2] ??
+    (await resolvePackagedAppBinary({
+      executableName: releaseConfig.linuxExecutableName,
+      platform: process.platform,
+      productName: releaseConfig.applicationName,
+      releaseDir: resolve(
+        dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "release",
+      ),
+    }));
+  await smokePackagedNpm(appBinary);
+}

--- a/turbo.json
+++ b/turbo.json
@@ -262,6 +262,23 @@
       "outputs": [],
       "passThroughEnv": ["*"]
     },
+    "@bb/desktop#smoke:packaged-npm": {
+      "cache": false,
+      "outputs": [],
+      "passThroughEnv": ["BB_DESKTOP_RELEASE_CHANNEL"]
+    },
+    "@bb/desktop#package": {
+      "dependsOn": ["bb-app#build", "@bb/desktop#build"],
+      "cache": false,
+      "outputs": ["release/**"],
+      "passThroughEnv": ["*"]
+    },
+    "@bb/desktop#package:linux": {
+      "dependsOn": ["bb-app#build", "@bb/desktop#build"],
+      "cache": false,
+      "outputs": ["release/**"],
+      "passThroughEnv": ["*"]
+    },
     "@bb/desktop#smoke:appimage-lifecycle": {
       "cache": false,
       "outputs": [],


### PR DESCRIPTION
## Human comments

## What was wrong

Desktop 0.43.0 ships npm 11.16.0 without its bundled dependencies. Electron-builder's pnpm collector treats npm as a leaf, and its dependency copier excludes nested `node_modules`. Source builds and the separate bb-app tarball smoke pass, while packaged npm exits 7 with missing `proc-log` and cannot install or update plugin dependencies.

## What changed

Preserve npm's complete nested dependency tree through an explicit shared electron-builder file set, before signing. The same file-set approach was proposed in closed, unmerged #3587.

Gate native-host packaging in `afterPack` on an artifact smoke test, and repeat it in packaged desktop smoke. The test runs the shipped npm through bundled Electron with an empty PATH and isolated HOME/cache/config. It audits required CJS/ESM dependency resolution and version ranges, imports ESM dependencies, and performs an offline disposable plugin dependency install and update from 1.0.0 to 2.0.0. Lockfile contents and actual ESM imports verify both operations; resource hashes reject bundle mutations. Document standalone npm smoke and add Turbo prerequisites for local packaging.

No server/daemon wire or public SDK changes.

## How you verified

- On a MacBook Air, both a freshly downloaded signed macOS 0.43.0 release and current-main packaged output lacked 60/65 direct npm dependencies and exited 7 through their own Electron runtime with no executables on PATH.
- Fixed real macOS arm64 packaging passes: all 65 direct dependencies, 144 packages including npm, and 348 required CJS/ESM dependency edges. Offline install/update succeeds and resources remain unchanged. An ad hoc signed disposable copy still passes strict codesign verification afterward.
- Negative controls reject removal of the new file set during real packaging, a missing Chalk ESM implementation file, and a nested dependency omission that resolves an incompatible minipass version.
- `pnpm exec turbo run package --filter=@bb/desktop`: passed, including the pre-signing npm gate.
- `pnpm exec turbo run typecheck test --filter=@bb/desktop`: passed; 322 tests passed, 1 existing skip. The sandbox initially aborted the existing Electron preload test; the macOS-process-enabled rerun passed.
- Formatting, `git diff --check`, and the public-content scan passed.
- The reported self-repair was not reproduced on the shipped dependency-install path: two attempts failed, all 9,225 release bundle files remained unchanged, and strict codesign verification still passed.

Independent Linux verification on x86_64/glibc 2.44 at commit `1d1ec370a90d53d97dc76d5b3998368ecf8aba88`:

- A freshly downloaded official 0.43.0 AppImage reproduces 60/65 missing dependencies and exit 7 for both version and real offline dependency-install commands through bundled Electron with an empty PATH. A repeated install also fails without changing resource hashes; no self-repair was observed.
- Real Turbo Linux packaging and the final **extracted AppImage executable** pass all 65 direct dependency, 144 package, and 348 CJS/ESM dependency-edge checks, including version ranges, offline install/update, and unchanged resources. Final AppImage SHA256: `f17e6bf79d3a26b92b6ce26ad2825b81fb5541a1a3d361cc60188d2a3c31024d`.
- Extracted AppImage GUI preload smoke passes under disposable Xvfb; the official-release baseline passes too.
- Both artifact negative controls fail as intended: missing Chalk ESM implementation and missing nested minipass dependencies with an incompatible fallback version.
- Turbo typecheck passes; 322 desktop tests and 81 bb-app tests pass, with one existing desktop skip. No PR-caused defects or source changes were needed.

Limitations: Linux AppImage FUSE lifecycle testing is blocked identically before and after (exit 127; host lacks `/dev/fuse` and `fusermount`); extracted-artifact checks above pass. macOS packaged GUI readiness timed out on both before and after artifacts. Developer ID signing/notarization and full Extensions UI activation were not tested. The new runtime gate requires a native target host. All verification used disposable artifacts and fixtures; no installed production app or store was modified.

Fixes #3566
Fixes #3581
Fixes #3584

> AGENT GENERATED
