### PR TITLE
Load model catalogs optimistically per machine

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -15,6 +15,7 @@ import type {
 } from "@bb/server-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { systemExecutionOptionsQueryKey } from "@/hooks/queries/query-keys";
+import { sdk } from "@/lib/sdk";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import {
@@ -665,6 +666,47 @@ describe("ModelReasoningPicker", () => {
     expect(onSelectedProviderChange).toHaveBeenCalledTimes(1);
     expect(onModelChange).toHaveBeenCalledWith("claude-opus-4-7");
   });
+
+  it.each([
+    {
+      label: "fetches every sibling",
+      locked: false,
+      expected: ["cursor", "pi"],
+    },
+    { label: "fetches nothing", locked: true, expected: [] },
+  ])(
+    "$label on the routed host when opened with switching locked: $locked",
+    async ({ locked, expected }) => {
+      vi.mocked(sdk.system.executionOptions).mockImplementation(
+        () => new Promise<SystemExecutionOptionsResponse>(() => undefined),
+      );
+      renderPicker({
+        ...(locked ? { onSelectedProviderChange: null } : {}),
+        providerRouting: { hostId: "h1" },
+        pickerProviderOptions: [
+          { value: "codex", label: "Codex" },
+          { value: "cursor", label: "Cursor" },
+          { value: "pi", label: "Pi" },
+        ],
+      });
+      expect(sdk.system.executionOptions).not.toHaveBeenCalled();
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Provider, model and reasoning" }),
+      );
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      });
+
+      expect(screen.getByRole("dialog")).not.toBeNull();
+      expect(
+        vi
+          .mocked(sdk.system.executionOptions)
+          .mock.calls.map(([args]) => `${args?.hostId}/${args?.providerId}`)
+          .sort(),
+      ).toEqual(expected.map((providerId) => `h1/${providerId}`));
+    },
+  );
 
   it("loads provider models on the compose-selected host", async () => {
     renderPicker({ providerRouting: { hostId: "host-remote" } });

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -13,6 +13,7 @@ import type {
   SystemProvidersQuery,
 } from "@bb/server-contract";
 import type { ReasoningLevel } from "@bb/domain";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   stripModelBrandPrefix,
   type ProviderPickerOption,
@@ -43,7 +44,10 @@ import {
   useMenuItemHover,
 } from "@bb/shared-ui/menu-item-hover";
 import { cn } from "@bb/shared-ui/lib/utils";
-import { useSystemExecutionOptions } from "@/hooks/queries/system-queries";
+import {
+  prefetchSystemExecutionOptions,
+  useSystemExecutionOptions,
+} from "@/hooks/queries/system-queries";
 import { resolveModelCatalogSelection } from "@/hooks/thread-creation-options/model-catalog-selection";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import {
@@ -284,6 +288,32 @@ export function ModelReasoningPicker({
     hasMultipleProviders &&
     onSelectedProviderChange !== undefined &&
     providerOptions.length > 1;
+  const queryClient = useQueryClient();
+  const prefetchRoutingEnvironmentId = providerRouting?.environmentId;
+  const prefetchRoutingHostId = providerRouting?.hostId;
+  const siblingIdsKey = providerOptions
+    .map((option) => option.value)
+    .filter((id) => id !== selectedProviderId)
+    .join("\0");
+  useEffect(() => {
+    if (!open || !canSwitchProviders || siblingIdsKey.length === 0) {
+      return;
+    }
+    prefetchSystemExecutionOptions(queryClient, {
+      routing: {
+        environmentId: prefetchRoutingEnvironmentId,
+        hostId: prefetchRoutingHostId,
+      },
+      providerIds: siblingIdsKey.split("\0"),
+    });
+  }, [
+    canSwitchProviders,
+    open,
+    prefetchRoutingEnvironmentId,
+    prefetchRoutingHostId,
+    queryClient,
+    siblingIdsKey,
+  ]);
   const hasAlternateSelectionPath =
     modelOptions.length > 0 ||
     (selectedModelLoadErrorMatches && canSwitchProviders);

--- a/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
+++ b/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
@@ -203,6 +203,7 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
     "allThreadStoragePathsQueryKeyPrefix",
     "allThreadTimelineQueryKeyPrefix",
     "allThreadTimelineTurnSummaryDetailsQueryKeyPrefix",
+    "environmentQueryKey",
     "hostsQueryKey",
     "hostPathExistenceQueryKeyPrefix",
     "projectsQueryKey",

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -26,6 +26,7 @@ import {
   updateCachedThreadListStatusState,
 } from "./query-cache";
 import { bumpDiffPatchFreshnessGeneration } from "./environment-diff-patch-cache-owner";
+import { invalidateSystemExecutionOptions } from "./system-cache-effects";
 import {
   getCachedThreadLists,
   iterateThreadListCacheEntries,
@@ -501,15 +502,21 @@ const HOST_CONNECTION_DIRTY_HANDLERS = [
   dirtyHostAvailabilityQueries,
   getProjectListInvalidationQueryKeys,
   dirtySystemProviderQueries,
-  dirtySystemExecutionOptionQueries,
 ] satisfies readonly RealtimeDirtyHandler<HostRealtimeDirtyContext>[];
 
 export const REALTIME_HOST_CHANGE_REGISTRY = {
   "host-connected": {
-    dirty: [...HOST_CONNECTION_DIRTY_HANDLERS, dirtyAllThreadStorageQueries],
+    dirty: [
+      ...HOST_CONNECTION_DIRTY_HANDLERS,
+      dirtyHostSystemExecutionOptionQueries,
+      dirtyAllThreadStorageQueries,
+    ],
   },
   "host-disconnected": {
     dirty: HOST_CONNECTION_DIRTY_HANDLERS,
+  },
+  "provider-model-catalog-changed": {
+    dirty: [dirtyHostSystemExecutionOptionQueries],
   },
 } satisfies HostChangeRegistry;
 
@@ -580,7 +587,9 @@ interface ProjectRealtimeDirtyContext extends RealtimeDirtyContext {
   projectId: string | undefined;
 }
 
-type HostRealtimeDirtyContext = RealtimeDirtyContext;
+interface HostRealtimeDirtyContext extends RealtimeDirtyContext {
+  hostId: string | undefined;
+}
 
 type RealtimeDirtyHandler<Context extends RealtimeDirtyContext> = (
   context: Context,
@@ -1157,6 +1166,14 @@ function dirtySystemProviderQueries(): QueryKey[] {
 
 function dirtySystemExecutionOptionQueries(): QueryKey[] {
   return [allSystemExecutionOptionsQueryKeyPrefix()];
+}
+
+function dirtyHostSystemExecutionOptionQueries({
+  hostId,
+  queryClient,
+}: HostRealtimeDirtyContext): QueryKey[] | void {
+  if (hostId === undefined) return [allSystemExecutionOptionsQueryKeyPrefix()];
+  void invalidateSystemExecutionOptions({ hostId, queryClient });
 }
 
 function dirtyPluginContributionQueries(): QueryKey[] {

--- a/apps/app/src/hooks/cache-owners/system-cache-effects.ts
+++ b/apps/app/src/hooks/cache-owners/system-cache-effects.ts
@@ -1,4 +1,6 @@
 import type { QueryKey } from "@tanstack/react-query";
+import type { Environment } from "@bb/domain";
+import type { SystemConfigResponse } from "@bb/server-contract";
 import {
   allEnvironmentDiffFilesQueryKeyPrefix,
   allEnvironmentDiffPatchQueryKeyPrefix,
@@ -25,6 +27,7 @@ import {
   allThreadStoragePathsQueryKeyPrefix,
   allThreadTimelineQueryKeyPrefix,
   allThreadTimelineTurnSummaryDetailsQueryKeyPrefix,
+  environmentQueryKey,
   hostPathExistenceQueryKeyPrefix,
   hostsQueryKey,
   projectsQueryKey,
@@ -126,10 +129,22 @@ export function invalidateSystemExecutionOptions({
   hostId,
   queryClient,
 }: SystemExecutionOptionsInvalidationArgs): Promise<void> {
+  const primaryHostId =
+    queryClient.getQueryData<SystemConfigResponse>(systemConfigQueryKey())
+      ?.primaryHostId ?? null;
   return queryClient.invalidateQueries({
     queryKey: allSystemExecutionOptionsQueryKeyPrefix(),
-    predicate: (query) =>
-      query.queryKey[2] === hostId || query.queryKey[2] === null,
+    predicate: (query) => {
+      const [, environmentId, routedHostId] = query.queryKey;
+      if (typeof routedHostId === "string") return routedHostId === hostId;
+      if (typeof environmentId === "string") {
+        const environment = queryClient.getQueryData<Environment>(
+          environmentQueryKey(environmentId),
+        );
+        return environment === undefined || environment.hostId === hostId;
+      }
+      return primaryHostId === null || primaryHostId === hostId;
+    },
   });
 }
 

--- a/apps/app/src/hooks/queries/system-queries.test.tsx
+++ b/apps/app/src/hooks/queries/system-queries.test.tsx
@@ -22,6 +22,7 @@ import {
   systemProvidersQueryKey,
 } from "./query-keys";
 import {
+  prefetchSystemExecutionOptions,
   useHostProviderCliStatus,
   useSystemExecutionOptions,
   useSystemProviderInfo,
@@ -588,6 +589,34 @@ describe("useSystemExecutionOptions", () => {
     expect(result.current[0]!.data?.models).toEqual([]);
     expect(result.current[1]!.isPlaceholderData).toBe(false);
     expect(result.current[1]!.data).toBeUndefined();
+  });
+
+  it("prefetches sibling catalogs without touching remembered localStorage catalogs", async () => {
+    vi.mocked(sdk.system.executionOptions).mockImplementation(async (args) => ({
+      ...CODEX_CATALOG,
+      models: [{ ...CODEX_MODEL, id: `${args?.providerId}-model` }],
+    }));
+    const { queryClient } = createQueryClientTestHarness();
+
+    prefetchSystemExecutionOptions(queryClient, {
+      routing: { hostId: "host-a" },
+      providerIds: ["pi", "claude-code"],
+    });
+
+    await waitFor(() => {
+      for (const providerId of ["pi", "claude-code"]) {
+        expect(
+          queryClient.getQueryData<SystemExecutionOptionsResponse>(
+            systemExecutionOptionsQueryKey({
+              environmentId: null,
+              hostId: "host-a",
+              providerId,
+            }),
+          )?.models[0]?.id,
+        ).toBe(`${providerId}-model`);
+      }
+    });
+    expect(window.localStorage.length).toBe(0);
   });
 
   it("retries one transient failure before surfacing model selector errors", async () => {

--- a/apps/app/src/hooks/queries/system-queries.ts
+++ b/apps/app/src/hooks/queries/system-queries.ts
@@ -4,7 +4,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import type { QueryKey } from "@tanstack/react-query";
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
 import type {
   PermissionMode,
   ProviderInfo,
@@ -36,7 +36,10 @@ import {
   readCachedProviderList,
   writeCachedProviderList,
 } from "@/lib/provider-list-cache";
-import { useSystemRealtimeSubscription } from "@/hooks/useRealtimeSubscription";
+import {
+  useHostListRealtimeSubscription,
+  useSystemRealtimeSubscription,
+} from "@/hooks/useRealtimeSubscription";
 import {
   allSystemExecutionOptionsQueryKeyPrefix,
   allSystemProvidersQueryKeyPrefix,
@@ -63,6 +66,13 @@ interface UseSystemExecutionOptionsArgs {
   environmentId?: string;
   hostId?: string;
   providerId?: string;
+}
+
+interface SystemExecutionOptionsQueryArgs {
+  environmentId: string | null;
+  hostId: string | null;
+  providerId: string | null;
+  writeLastKnown: boolean;
 }
 
 interface UseSystemProviderStatesOptions extends QueryOptions {
@@ -272,6 +282,65 @@ export function useSystemProviderInfo({
   );
 }
 
+function systemExecutionOptionsQueryOptions({
+  environmentId,
+  hostId,
+  providerId,
+  writeLastKnown,
+}: SystemExecutionOptionsQueryArgs) {
+  return queryOptions<SystemExecutionOptionsResponse>({
+    queryKey: systemExecutionOptionsQueryKey({
+      environmentId,
+      hostId,
+      providerId,
+    }),
+    queryFn: async ({ signal }) => {
+      const response = await sdk.system.executionOptions({
+        environmentId: environmentId ?? undefined,
+        hostId: hostId ?? undefined,
+        providerId: providerId ?? undefined,
+        signal,
+      });
+      if (writeLastKnown) {
+        writeCachedProviderList(
+          providerListCacheKey({ environmentId, hostId }),
+          response.providers,
+        );
+        if (response.modelLoadError === null) {
+          const catalog = {
+            models: response.models,
+            selectedOnlyModels: response.selectedOnlyModels,
+          };
+          writeCachedModelCatalog(
+            modelCatalogCacheKey({ environmentId, hostId, providerId }),
+            catalog,
+          );
+        }
+      }
+      return response;
+    },
+    staleTime: 60_000,
+    retry: shouldRetrySystemExecutionOptions,
+    retryDelay: SYSTEM_EXECUTION_OPTIONS_RETRY_DELAY_MS,
+  });
+}
+
+export function prefetchSystemExecutionOptions(
+  queryClient: QueryClient,
+  args: { routing: SystemProvidersQuery; providerIds: readonly string[] },
+): void {
+  for (const providerId of args.providerIds) {
+    void queryClient.prefetchQuery(
+      systemExecutionOptionsQueryOptions({
+        environmentId: args.routing.environmentId ?? null,
+        hostId: args.routing.hostId ?? null,
+        providerId,
+        writeLastKnown: false,
+      }),
+    );
+  }
+}
+
 export function useSystemExecutionOptions(
   args: UseSystemExecutionOptionsArgs = {},
 ) {
@@ -280,39 +349,21 @@ export function useSystemExecutionOptions(
   const providerId = args.providerId ?? null;
   const enabled = args.enabled ?? true;
   useSystemRealtimeSubscription({ enabled });
+  useHostListRealtimeSubscription({ enabled });
   const providersCacheKey = providerListCacheKey({ environmentId, hostId });
   const catalogCacheKey = modelCatalogCacheKey({
     environmentId,
     hostId,
     providerId,
   });
-  return useQuery<SystemExecutionOptionsResponse>({
-    queryKey: systemExecutionOptionsQueryKey({
+  return useQuery({
+    ...systemExecutionOptionsQueryOptions({
       environmentId,
       hostId,
       providerId,
+      writeLastKnown: true,
     }),
-    queryFn: async ({ signal }) => {
-      const response = await sdk.system.executionOptions({
-        environmentId: args.environmentId,
-        hostId: args.hostId,
-        providerId: args.providerId,
-        signal,
-      });
-      writeCachedProviderList(providersCacheKey, response.providers);
-      if (response.modelLoadError === null) {
-        const catalog = {
-          models: response.models,
-          selectedOnlyModels: response.selectedOnlyModels,
-        };
-        writeCachedModelCatalog(catalogCacheKey, catalog);
-      }
-      return response;
-    },
     enabled,
-    staleTime: 60_000,
-    retry: shouldRetrySystemExecutionOptions,
-    retryDelay: SYSTEM_EXECUTION_OPTIONS_RETRY_DELAY_MS,
     placeholderData: (previousData, previousQuery) =>
       resolveExecutionOptionsPlaceholder({
         previousData,

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -7,14 +7,18 @@ import {
   SYSTEM_CHANGE_KINDS,
   THREAD_CHANGE_KINDS,
 } from "@bb/domain";
+import type { QueryClient } from "@tanstack/react-query";
+import { makeEnvironment } from "@bb/test-helpers/domain-fixtures";
 import { createAppQueryClient } from "@/lib/query-client";
 import {
   archivedThreadsListQueryKey,
   environmentDiffFilesQueryKey,
   environmentDiffPatchQueryKey,
   environmentPullRequestQueryKey,
+  environmentQueryKey,
   environmentWorkStatusQueryKey,
   hostPathExistenceQueryKey,
+  hostsQueryKey,
   projectPathsQueryKey,
   projectCommandsQueryKey,
   projectFilePreviewQueryKey,
@@ -376,6 +380,117 @@ describe("createRealtimeCacheEffects", () => {
     expect(queryClient.getQueryState(executionOptionsKey)?.isInvalidated).toBe(
       true,
     );
+  });
+
+  describe("host-scoped execution options", () => {
+    function seedExecutionOptions(
+      queryClient: QueryClient,
+      primaryHostId: string | null,
+    ) {
+      queryClient.setQueryData(systemConfigQueryKey(), { primaryHostId });
+      for (const [id, hostId] of [
+        ["env-a", "host-a"],
+        ["env-b", "host-b"],
+      ]) {
+        queryClient.setQueryData(
+          environmentQueryKey(id),
+          makeEnvironment({ id, hostId }),
+        );
+      }
+      const keys = Object.entries({
+        hostA: { environmentId: null, hostId: "host-a" },
+        hostB: { environmentId: null, hostId: "host-b" },
+        envHostA: { environmentId: "env-a", hostId: null },
+        envHostB: { environmentId: "env-b", hostId: null },
+        envUnknown: { environmentId: "env-unknown", hostId: null },
+        primary: { environmentId: null, hostId: null },
+      }).map(
+        ([name, routing]) =>
+          [
+            name,
+            systemExecutionOptionsQueryKey({ ...routing, providerId: "codex" }),
+          ] as const,
+      );
+      for (const [, queryKey] of keys) {
+        queryClient.setQueryData(queryKey, {});
+      }
+      return () =>
+        keys
+          .filter(
+            ([, queryKey]) =>
+              queryClient.getQueryState(queryKey)?.isInvalidated,
+          )
+          .map(([name]) => name)
+          .sort();
+    }
+
+    it.each([
+      {
+        id: "host-a",
+        primaryHostId: "host-a",
+        expected: ["envHostA", "envUnknown", "hostA", "primary"],
+      },
+      {
+        id: "host-a",
+        primaryHostId: "host-b",
+        expected: ["envHostA", "envUnknown", "hostA"],
+      },
+      {
+        id: "host-a",
+        primaryHostId: null,
+        expected: ["envHostA", "envUnknown", "hostA", "primary"],
+      },
+      {
+        id: undefined,
+        primaryHostId: "host-b",
+        expected: [
+          "envHostA",
+          "envHostB",
+          "envUnknown",
+          "hostA",
+          "hostB",
+          "primary",
+        ],
+      },
+    ])(
+      "refreshes only matching catalogs on a catalog push from $id while the primary host is $primaryHostId",
+      ({ id, primaryHostId, expected }) => {
+        const { effects, queryClient } = createRealtimeEffectsTestContext();
+        const invalidated = seedExecutionOptions(queryClient, primaryHostId);
+
+        effects.handleChanged({
+          type: "changed",
+          entity: "host",
+          ...(id === undefined ? {} : { id }),
+          changes: ["provider-model-catalog-changed"],
+        });
+
+        expect(invalidated()).toEqual(expected);
+        effects.dispose();
+      },
+    );
+
+    it("refreshes hosts and providers but not catalogs when a host disconnects", () => {
+      const { effects, queryClient } = createRealtimeEffectsTestContext();
+      const invalidated = seedExecutionOptions(queryClient, "host-a");
+      const providersKey = systemProvidersQueryKey({ hostId: "host-a" });
+      queryClient.setQueryData(hostsQueryKey(), []);
+      queryClient.setQueryData(providersKey, []);
+
+      effects.handleChanged({
+        type: "changed",
+        entity: "host",
+        id: "host-a",
+        changes: ["host-disconnected"],
+      });
+
+      expect(queryClient.getQueryState(hostsQueryKey())?.isInvalidated).toBe(
+        true,
+      );
+      expect(queryClient.getQueryState(providersKey)?.isInvalidated).toBe(true);
+      expect(invalidated()).toEqual([]);
+      effects.dispose();
+    });
   });
 
   it("invalidates timelines when config changes provider event visibility", () => {

--- a/apps/app/src/hooks/realtime-cache-effects.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.ts
@@ -410,10 +410,13 @@ export function createRealtimeCacheEffects({
     maxWaitMs: ENVIRONMENT_INVALIDATION_MAX_WAIT_MS,
   });
 
-  const applyHostChanges = (changeKinds: Iterable<HostChangeKind>): void => {
+  const applyHostChanges = (
+    hostId: string | undefined,
+    changeKinds: Iterable<HostChangeKind>,
+  ): void => {
     for (const changeKind of changeKinds) {
       executeRealtimeDirtyHandlers({
-        context: { queryClient },
+        context: { hostId, queryClient },
         handlers: REALTIME_HOST_CHANGE_REGISTRY[changeKind].dirty,
       });
     }
@@ -454,7 +457,7 @@ export function createRealtimeCacheEffects({
           Array.from(changeKinds),
         );
       }
-      applyHostChanges(hostKinds);
+      applyHostChanges(undefined, hostKinds);
       for (const [projectId, changeKinds] of projectKindsById) {
         applyProjectChanges(projectId, changeKinds);
       }
@@ -535,7 +538,7 @@ export function createRealtimeCacheEffects({
             addAll(deferredNonThreadChanges.hostKinds, message.changes);
             break;
           }
-          applyHostChanges(message.changes);
+          applyHostChanges(message.id, message.changes);
           break;
         case "project":
           if (!documentVisible) {

--- a/apps/app/src/lib/system-config-atoms.local-access.test.ts
+++ b/apps/app/src/lib/system-config-atoms.local-access.test.ts
@@ -334,6 +334,66 @@ describe("local host daemon access atoms", () => {
     unsubscribe();
   });
 
+  it("refreshes config and status discovery only for host connection changes", async () => {
+    vi.stubGlobal("navigator", {
+      permissions: {
+        query: vi.fn(async () => ({ state: "granted" })),
+      },
+      userAgent: "test",
+    });
+    mocks.fetchHostStatus.mockResolvedValue({
+      connected: true,
+      hostId: "host-local",
+      serverUrl: "https://remote.getbb.app",
+    });
+    const store = createStore();
+    const unsubscribe = store.sub(localHostStatusAtom, () => {});
+    const configRequestCount = () =>
+      mocks.fetchSdkSystemConfig.mock.calls.length +
+      mocks.fetchSystemConfig.mock.calls.length;
+    const notifyChanged = (message: ChangedMessage) => {
+      for (const [listener] of mocks.onChanged.mock.calls) {
+        listener(message);
+      }
+    };
+
+    try {
+      await expect(store.get(localHostStatusAtom)).resolves.toMatchObject({
+        hostId: "host-local",
+      });
+      const hostStatusRequests = mocks.fetchHostStatus.mock.calls.length;
+      const configRequests = configRequestCount();
+
+      notifyChanged({
+        type: "changed",
+        entity: "host",
+        id: "h1",
+        changes: ["provider-model-catalog-changed"],
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await expect(store.get(localHostStatusAtom)).resolves.toMatchObject({
+        hostId: "host-local",
+      });
+      expect(mocks.fetchHostStatus).toHaveBeenCalledTimes(hostStatusRequests);
+      expect(configRequestCount()).toBe(configRequests);
+
+      notifyChanged({
+        type: "changed",
+        entity: "host",
+        id: "h1",
+        changes: ["host-connected"],
+      });
+      await vi.waitFor(() => {
+        expect(mocks.fetchHostStatus.mock.calls.length).toBeGreaterThan(
+          hostStatusRequests,
+        );
+        expect(configRequestCount()).toBeGreaterThan(configRequests);
+      });
+    } finally {
+      unsubscribe();
+    }
+  });
+
   it("does not probe loopback while a remote page is in prompt state", async () => {
     const store = createStore();
 

--- a/apps/app/src/lib/system-config-atoms.ts
+++ b/apps/app/src/lib/system-config-atoms.ts
@@ -179,12 +179,18 @@ systemConfigRefreshTickAtom.onMount = (setRefreshTick) => {
     setRefreshTick((count) => count + 1);
   });
   const unsubscribeChanged = wsManager.onChanged((message) => {
+    const hostConnectionChanged =
+      message.entity === "host" &&
+      message.changes.some(
+        (change) =>
+          change === "host-connected" || change === "host-disconnected",
+      );
     if (
-      message.entity === "host" ||
+      hostConnectionChanged ||
       (message.entity === "system" &&
         message.changes.includes("config-changed"))
     ) {
-      if (message.entity === "host") {
+      if (hostConnectionChanged) {
         invalidateSystemConfig();
       }
       setRefreshTick((count) => count + 1);

--- a/apps/server/src/lifecycle-dedupers.ts
+++ b/apps/server/src/lifecycle-dedupers.ts
@@ -1,4 +1,3 @@
-import type { AvailableModel } from "@bb/domain";
 import {
   createAsyncDeduper,
   createAsyncRerunner,
@@ -6,27 +5,24 @@ import {
   type AsyncRerunner,
 } from "./services/lib/async-deduper.js";
 import {
-  createAsyncTtlMemo,
-  type AsyncTtlMemo,
-} from "./services/lib/async-ttl-memo.js";
-
-const PROVIDER_MODEL_LIST_MEMO_TTL_MS = 10 * 60_000;
-
-export interface ProviderModelListMemoValue {
-  models: AvailableModel[];
-  selectedOnlyModels: AvailableModel[];
-}
+  createProviderModelCatalogStore,
+  PROVIDER_MODEL_CATALOG_MEMORY_ENTRY_LIMIT,
+  PROVIDER_MODEL_CATALOG_PUSH_COALESCE_MS,
+  type ProviderModelCatalogStore,
+} from "./services/providers/provider-model-catalog-store.js";
 
 export interface LifecycleDedupers {
-  providerModelList: AsyncTtlMemo<string, ProviderModelListMemoValue>;
+  providerModelCatalogs: ProviderModelCatalogStore;
   queuedMessageDispatch: AsyncDeduper<string, void>;
   threadProvisionAdvance: AsyncRerunner<string>;
 }
 
 export function createLifecycleDedupers(): LifecycleDedupers {
   return {
-    providerModelList: createAsyncTtlMemo<string, ProviderModelListMemoValue>({
-      ttlMs: PROVIDER_MODEL_LIST_MEMO_TTL_MS,
+    providerModelCatalogs: createProviderModelCatalogStore({
+      now: Date.now,
+      pushCoalesceMs: PROVIDER_MODEL_CATALOG_PUSH_COALESCE_MS,
+      memoryEntryLimit: PROVIDER_MODEL_CATALOG_MEMORY_ENTRY_LIMIT,
     }),
     queuedMessageDispatch: createAsyncDeduper<string, void>(),
     threadProvisionAdvance: createAsyncRerunner<string>(),

--- a/apps/server/src/routes/hosts.ts
+++ b/apps/server/src/routes/hosts.ts
@@ -261,6 +261,7 @@ export function registerHostRoutes(
       handleHostRemoved(deps, { hostId, sessionId });
     }
     updateHost(deps.db, deps.hub, hostId, { destroyedAt: Date.now() });
+    deps.lifecycleDedupers.providerModelCatalogs.forgetHost(deps, hostId);
     if (host.connectMachineId !== null) {
       await revokeConnectMachineCredential(
         deps,
@@ -383,6 +384,10 @@ export function registerHostRoutes(
         hostId,
         providerId: payload.provider,
       });
+      deps.lifecycleDedupers.providerModelCatalogs.clearFailure(
+        hostId,
+        payload.provider,
+      );
     }
     return new Response(providerCliInstallEventsToNdjson(result.events), {
       headers: {

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -251,6 +251,7 @@ export function registerSystemRoutes(
         "Machine credentials cannot change global environment settings",
       );
     await replaceMachineEnvironment(deps.db, deps.config.dataDir, payload);
+    deps.lifecycleDedupers.providerModelCatalogs.markAllStale();
     deps.hub.notifySystem(["config-changed"]);
     return context.json(
       await machineEnvironmentView(deps.db, deps.config.dataDir),

--- a/apps/server/src/services/environments/workspace-read-cache.test.ts
+++ b/apps/server/src/services/environments/workspace-read-cache.test.ts
@@ -255,6 +255,20 @@ describe("WorkspaceReadCaches", () => {
     expect(await primed.readBoth()).toEqual({ status: 2, pullRequest: 2 });
   });
 
+  it("keeps a host's cached reads when only its provider model catalog changed", async () => {
+    const hub = createFakeHub();
+    const caches = new WorkspaceReadCaches({ hub, now: () => 0 });
+    const primed = await primeBoth(caches);
+
+    hub.emit({
+      type: "changed",
+      entity: "host",
+      id: "host-1",
+      changes: ["provider-model-catalog-changed"],
+    });
+    expect(await primed.readBoth()).toEqual({ status: 1, pullRequest: 1 });
+  });
+
   it("drops both caches when a server-side mutation invalidates the environment or host", async () => {
     const hub = createFakeHub();
     const caches = new WorkspaceReadCaches({ hub, now: () => 0 });

--- a/apps/server/src/services/environments/workspace-read-cache.ts
+++ b/apps/server/src/services/environments/workspace-read-cache.ts
@@ -167,7 +167,13 @@ export class WorkspaceReadCaches {
       this.invalidateEnvironment(message.id);
       return;
     }
-    if (message.entity === "host") {
+    if (
+      message.entity === "host" &&
+      message.changes.some(
+        (change) =>
+          change === "host-connected" || change === "host-disconnected",
+      )
+    ) {
       this.invalidateHost(message.id);
     }
   }

--- a/apps/server/src/services/lib/error-log-fields.ts
+++ b/apps/server/src/services/lib/error-log-fields.ts
@@ -8,8 +8,33 @@ interface ProductionErrorLogFields {
   errorStatus?: number;
 }
 
+interface ExpectedFallbackErrorLogFields {
+  errorCode: string;
+  errorDetails?: unknown;
+  errorMessage: string;
+  errorRetryable?: boolean;
+  errorStatus: number;
+}
+
 type LoggableError = unknown;
 type RuntimeErrorLogFields = { err: LoggableError } | ProductionErrorLogFields;
+
+export function expectedFallbackErrorLogFields(
+  error: ApiError,
+): ExpectedFallbackErrorLogFields {
+  const fields: ExpectedFallbackErrorLogFields = {
+    errorCode: error.body.code,
+    errorMessage: error.body.message,
+    errorStatus: error.status,
+  };
+  if (error.body.details !== undefined) {
+    fields.errorDetails = error.body.details;
+  }
+  if (error.body.retryable !== undefined) {
+    fields.errorRetryable = error.body.retryable;
+  }
+  return fields;
+}
 
 export function productionErrorLogFields(
   error: LoggableError,

--- a/apps/server/src/services/machines/provider-orchestration.ts
+++ b/apps/server/src/services/machines/provider-orchestration.ts
@@ -1214,6 +1214,7 @@ async function removeMachine(deps: Deps, hostId: string): Promise<void> {
           teardownStatus: "removed",
           statusMessage: creationFailureMessage,
         });
+        deps.lifecycleDedupers.providerModelCatalogs.forgetHost(deps, hostId);
         deps.hub.notifyHost(hostId, ["host-disconnected"]);
       } catch (error) {
         const current = getHost(deps.db, hostId);

--- a/apps/server/src/services/providers/provider-model-catalog-prewarm.ts
+++ b/apps/server/src/services/providers/provider-model-catalog-prewarm.ts
@@ -1,0 +1,154 @@
+import { getHost } from "@bb/db";
+import type { LoggedWorkSessionDeps } from "../../types.js";
+import { runtimeErrorLogFields } from "../lib/error-log-fields.js";
+import { listSystemProviderInfosForHost } from "../system/execution-options.js";
+
+const PER_HOST_CONCURRENCY = 2;
+const GLOBAL_CONCURRENCY = 4;
+
+export function installProviderModelCatalogPrewarm(
+  deps: LoggedWorkSessionDeps,
+): { stop(): void } {
+  const pendingHosts = new Set<string>();
+  const runningHosts = new Set<string>();
+  const globalWaiters: (() => void)[] = [];
+  let globalRunning = 0;
+  let stopped = false;
+
+  function request(hostId: string): void {
+    if (stopped) {
+      return;
+    }
+    pendingHosts.add(hostId);
+    if (!runningHosts.has(hostId)) {
+      void runPasses(hostId);
+    }
+  }
+
+  async function runPasses(hostId: string): Promise<void> {
+    runningHosts.add(hostId);
+    try {
+      while (!stopped && pendingHosts.delete(hostId)) {
+        try {
+          await runPass(hostId);
+        } catch (error) {
+          deps.logger.error(
+            { hostId, ...runtimeErrorLogFields(deps.config, error) },
+            "Provider model catalog prewarm pass failed",
+          );
+        }
+      }
+    } finally {
+      runningHosts.delete(hostId);
+    }
+  }
+
+  async function acquireGlobalSlot(): Promise<void> {
+    if (globalRunning < GLOBAL_CONCURRENCY) {
+      globalRunning += 1;
+      return;
+    }
+    await new Promise<void>((resolve) => globalWaiters.push(resolve));
+  }
+
+  function releaseGlobalSlot(): void {
+    const next = globalWaiters.shift();
+    if (next === undefined) {
+      globalRunning -= 1;
+    } else {
+      next();
+    }
+  }
+
+  async function runPass(hostId: string): Promise<void> {
+    const startedAt = Date.now();
+    await deps.providerRegistry.whenRegistrationsSettled();
+    const sessionId = deps.hub.getDaemonSessionIdForHost(hostId);
+    const host = getHost(deps.db, hostId);
+    if (
+      stopped ||
+      sessionId === null ||
+      host === null ||
+      host.destroyedAt !== null ||
+      host.type === "ephemeral" ||
+      host.phase !== "active"
+    ) {
+      return;
+    }
+    const providers = await listSystemProviderInfosForHost(deps, hostId);
+    const defaultProviderId = deps.providerRegistry.getUserDefaultProviderId();
+    const queue = providers
+      .filter((provider) => provider.available)
+      .sort(
+        (left, right) =>
+          Number(right.id === defaultProviderId) -
+          Number(left.id === defaultProviderId),
+      );
+    const providerCount = queue.length;
+    await Promise.all(
+      Array.from({ length: PER_HOST_CONCURRENCY }, async () => {
+        for (
+          let provider = queue.shift();
+          provider !== undefined;
+          provider = queue.shift()
+        ) {
+          await acquireGlobalSlot();
+          try {
+            if (
+              stopped ||
+              deps.hub.getDaemonSessionIdForHost(hostId) !== sessionId
+            ) {
+              return;
+            }
+            await deps.lifecycleDedupers.providerModelCatalogs.refreshForPrewarm(
+              deps,
+              { hostId, provider },
+            );
+          } catch (error) {
+            deps.logger.error(
+              {
+                hostId,
+                providerId: provider.id,
+                ...runtimeErrorLogFields(deps.config, error),
+              },
+              "Provider model catalog prewarm task failed",
+            );
+          } finally {
+            releaseGlobalSlot();
+          }
+        }
+      }),
+    );
+    deps.logger.info(
+      { hostId, providerCount, durationMs: Date.now() - startedAt },
+      "Provider model catalog prewarm pass finished",
+    );
+  }
+
+  const unsubscribe = deps.hub.onChangedMessage((message) => {
+    if (
+      message.entity === "host" &&
+      message.changes.includes("host-connected")
+    ) {
+      request(message.id);
+    } else if (
+      message.entity === "system" &&
+      message.changes.includes("provider-registrations-changed")
+    ) {
+      for (const hostId of deps.hub.listConnectedHostIds()) {
+        request(hostId);
+      }
+    }
+  });
+  for (const hostId of deps.hub.listConnectedHostIds()) {
+    request(hostId);
+  }
+
+  return {
+    stop() {
+      stopped = true;
+      unsubscribe();
+      pendingHosts.clear();
+    },
+  };
+}

--- a/apps/server/src/services/providers/provider-model-catalog-store.ts
+++ b/apps/server/src/services/providers/provider-model-catalog-store.ts
@@ -1,0 +1,588 @@
+import { createHash } from "node:crypto";
+import {
+  deleteStoredProviderModelCatalogsForHost,
+  getHost,
+  getStoredProviderModelCatalog,
+  replaceStoredProviderModelCatalog,
+  type ProviderModelCatalogRowKey,
+} from "@bb/db";
+import {
+  availableModelSchema,
+  providerModelCatalogDependsOnWorkspace,
+  type AvailableModel,
+  type ProviderInfo,
+} from "@bb/domain";
+import type { HostDaemonBridgeLaunch } from "@bb/host-daemon-contract";
+import type { SystemExecutionOptionsModelLoadErrorCode } from "@bb/server-contract";
+import { z } from "zod";
+import { COMMAND_TIMEOUT_MS } from "../../constants.js";
+import { ApiError } from "../../errors.js";
+import type { WorkSessionDeps } from "../../types.js";
+import {
+  callHostOnlineRpc,
+  isHostUnavailableApiError,
+} from "../hosts/online-rpc.js";
+import {
+  expectedFallbackErrorLogFields,
+  runtimeErrorLogFields,
+} from "../lib/error-log-fields.js";
+import {
+  requireBridgeLaunchForProviderId,
+  resolveBridgeLaunchForProviderId,
+} from "../system/provider-bridge-launch.js";
+
+export const PROVIDER_MODEL_CATALOG_PUSH_COALESCE_MS = 250;
+export const PROVIDER_MODEL_CATALOG_MEMORY_ENTRY_LIMIT = 256;
+const FRESH_MS = 10 * 60_000;
+const VALIDATION_MIN_AGE_MS = 60_000;
+const FAILURE_TTL_MS = 30_000;
+const PREWARM_MIN_AGE_MS = 4 * 60 * 60_000;
+const WORKSPACE_ROW_RETENTION_MS = 7 * 24 * 60 * 60_000;
+
+type ProviderModelCatalogFailureCode = Exclude<
+  SystemExecutionOptionsModelLoadErrorCode,
+  "provider_unavailable"
+>;
+
+export type ProviderModelCatalogAccess =
+  | { kind: "picker" }
+  | { kind: "validation"; requiredModel: string | null };
+
+type ProviderModelCatalogReadResult =
+  | {
+      kind: "catalog";
+      models: AvailableModel[];
+      selectedOnlyModels: AvailableModel[];
+    }
+  | { kind: "error"; code: ProviderModelCatalogFailureCode };
+
+export interface ProviderModelCatalogStore {
+  read(
+    deps: WorkSessionDeps,
+    args: {
+      hostId: string;
+      provider: ProviderInfo;
+      cwd: string | null;
+      access: ProviderModelCatalogAccess;
+    },
+  ): Promise<ProviderModelCatalogReadResult>;
+  refreshForPrewarm(
+    deps: WorkSessionDeps,
+    args: { hostId: string; provider: ProviderInfo },
+  ): Promise<void>;
+  clearFailure(hostId: string, providerId: string): void;
+  markAllStale(): void;
+  forgetHost(deps: WorkSessionDeps, hostId: string): void;
+}
+
+interface CatalogGood {
+  fingerprint: string;
+  models: AvailableModel[];
+  selectedOnlyModels: AvailableModel[];
+  modelsJson: string;
+  selectedOnlyModelsJson: string;
+  fetchedAt: number;
+}
+
+interface CatalogFailure {
+  fingerprint: string;
+  code: ProviderModelCatalogFailureCode;
+  failedAt: number;
+}
+
+interface CatalogRefresh {
+  fingerprint: string;
+  sessionId: string | null;
+  startedAt: number;
+  markedStale: boolean;
+  promise: Promise<void>;
+}
+
+interface CatalogEntry {
+  key: ProviderModelCatalogRowKey;
+  good: CatalogGood | null;
+  failure: CatalogFailure | null;
+  refresh: CatalogRefresh | null;
+}
+
+type RefreshSettlement =
+  | { ok: true; models: AvailableModel[]; selectedOnlyModels: AvailableModel[] }
+  | { ok: false; error: unknown };
+
+type CatalogDecision =
+  | {
+      kind: "serve";
+      result: ProviderModelCatalogReadResult;
+      backgroundRefresh: boolean;
+    }
+  | { kind: "wait" };
+
+const storedModelListSchema = z.array(availableModelSchema);
+
+export function toProviderModelCatalogFailureCode(
+  error: ApiError,
+): ProviderModelCatalogFailureCode {
+  switch (error.body.code) {
+    case "command_timeout":
+      return "timeout";
+    case "missing_executable":
+      return "missing_executable";
+    case "auth_required":
+      return "auth_required";
+    default:
+      return "failed";
+  }
+}
+
+function catalogFingerprint(
+  providerId: string,
+  bridgeLaunch: HostDaemonBridgeLaunch,
+): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify([
+        providerId,
+        bridgeLaunch.pluginId,
+        bridgeLaunch.source,
+        bridgeLaunch.providerOptions,
+        bridgeLaunch.envPassthrough,
+      ]),
+    )
+    .digest("hex");
+}
+
+function parseStoredModels(json: string): AvailableModel[] | null {
+  try {
+    const parsed = storedModelListSchema.safeParse(JSON.parse(json));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+function currentState(entry: CatalogEntry, fingerprint: string) {
+  const good = entry.good?.fingerprint === fingerprint ? entry.good : null;
+  const failure =
+    entry.failure?.fingerprint === fingerprint ? entry.failure : null;
+  const servable =
+    failure === null || failure.code === "timeout" || failure.code === "failed"
+      ? good
+      : null;
+  return { good, failure, servable };
+}
+
+function pickerView(entry: CatalogEntry, fingerprint: string): string {
+  const { failure, servable } = currentState(entry, fingerprint);
+  if (servable !== null) {
+    return `catalog:${servable.modelsJson}\0${servable.selectedOnlyModelsJson}`;
+  }
+  return failure === null ? "none" : `error:${failure.code}`;
+}
+
+function lacksRequiredModel(
+  good: CatalogGood,
+  requiredModel: string | null,
+): boolean {
+  if (requiredModel === null) {
+    return good.models.length === 0;
+  }
+  return ![...good.models, ...good.selectedOnlyModels].some(
+    (entry) => entry.model === requiredModel,
+  );
+}
+
+function evaluate(
+  entry: CatalogEntry,
+  fingerprint: string,
+  access: ProviderModelCatalogAccess,
+  now: number,
+  refreshed: boolean,
+): CatalogDecision {
+  const { failure, servable } = currentState(entry, fingerprint);
+  const active = failure !== null && now - failure.failedAt < FAILURE_TTL_MS;
+  if (servable !== null) {
+    const age = now - servable.fetchedAt;
+    if (
+      access.kind === "validation" &&
+      !refreshed &&
+      !active &&
+      age >= VALIDATION_MIN_AGE_MS &&
+      lacksRequiredModel(servable, access.requiredModel)
+    ) {
+      return { kind: "wait" };
+    }
+    return {
+      kind: "serve",
+      result: {
+        kind: "catalog",
+        models: servable.models,
+        selectedOnlyModels: servable.selectedOnlyModels,
+      },
+      backgroundRefresh: !refreshed && !active && age >= FRESH_MS,
+    };
+  }
+  if (refreshed) {
+    return {
+      kind: "serve",
+      result: { kind: "error", code: failure?.code ?? "failed" },
+      backgroundRefresh: false,
+    };
+  }
+  if (access.kind === "validation" || failure === null) {
+    return { kind: "wait" };
+  }
+  if (active || failure.code === "timeout") {
+    return {
+      kind: "serve",
+      result: { kind: "error", code: failure.code },
+      backgroundRefresh: !active,
+    };
+  }
+  return { kind: "wait" };
+}
+
+export function createProviderModelCatalogStore(options: {
+  now: () => number;
+  pushCoalesceMs: number;
+  memoryEntryLimit: number;
+}): ProviderModelCatalogStore {
+  const entries = new Map<string, CatalogEntry>();
+  const pendingPushByHost = new Map<string, ReturnType<typeof setTimeout>>();
+
+  function loadStoredGood(
+    deps: WorkSessionDeps,
+    key: ProviderModelCatalogRowKey,
+  ): CatalogGood | null {
+    const row = getStoredProviderModelCatalog(deps.db, key);
+    if (row === null) {
+      return null;
+    }
+    const models = parseStoredModels(row.modelsJson);
+    const selectedOnlyModels = parseStoredModels(row.selectedOnlyModelsJson);
+    if (models === null || selectedOnlyModels === null) {
+      return null;
+    }
+    return {
+      fingerprint: row.fingerprint,
+      models,
+      selectedOnlyModels,
+      modelsJson: row.modelsJson,
+      selectedOnlyModelsJson: row.selectedOnlyModelsJson,
+      fetchedAt: row.fetchedAt,
+    };
+  }
+
+  function loadEntry(
+    deps: WorkSessionDeps,
+    key: ProviderModelCatalogRowKey,
+  ): CatalogEntry {
+    const mapKey = JSON.stringify([key.hostId, key.providerId, key.scopeKey]);
+    const existing = entries.get(mapKey);
+    if (existing !== undefined) {
+      entries.delete(mapKey);
+      entries.set(mapKey, existing);
+      return existing;
+    }
+    const entry: CatalogEntry = {
+      key,
+      good: loadStoredGood(deps, key),
+      failure: null,
+      refresh: null,
+    };
+    entries.set(mapKey, entry);
+    for (const [victimKey, victim] of entries) {
+      if (entries.size <= options.memoryEntryLimit) {
+        break;
+      }
+      if (victim !== entry && victim.refresh === null) {
+        entries.delete(victimKey);
+      }
+    }
+    return entry;
+  }
+
+  function schedulePush(deps: WorkSessionDeps, hostId: string): void {
+    if (pendingPushByHost.has(hostId)) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      pendingPushByHost.delete(hostId);
+      deps.hub.notifyHost(hostId, ["provider-model-catalog-changed"]);
+    }, options.pushCoalesceMs);
+    timer.unref?.();
+    pendingPushByHost.set(hostId, timer);
+  }
+
+  function persistGood(
+    deps: WorkSessionDeps,
+    key: ProviderModelCatalogRowKey,
+    good: CatalogGood,
+  ): void {
+    try {
+      const host = getHost(deps.db, key.hostId);
+      if (
+        host === null ||
+        host.destroyedAt !== null ||
+        host.type === "ephemeral"
+      ) {
+        return;
+      }
+      replaceStoredProviderModelCatalog(deps.db, {
+        row: {
+          ...key,
+          fingerprint: good.fingerprint,
+          modelsJson: good.modelsJson,
+          selectedOnlyModelsJson: good.selectedOnlyModelsJson,
+          fetchedAt: good.fetchedAt,
+        },
+        pruneWorkspaceRowsFetchedBefore:
+          key.scopeKey === ""
+            ? null
+            : good.fetchedAt - WORKSPACE_ROW_RETENTION_MS,
+      });
+    } catch (error) {
+      deps.logger.warn(
+        {
+          hostId: key.hostId,
+          providerId: key.providerId,
+          ...runtimeErrorLogFields(deps.config, error),
+        },
+        "Failed to persist provider model catalog",
+      );
+    }
+  }
+
+  function settle(
+    deps: WorkSessionDeps,
+    entry: CatalogEntry,
+    refresh: CatalogRefresh,
+    settlement: RefreshSettlement,
+  ): void {
+    const { hostId, providerId, scopeKey } = entry.key;
+    const now = options.now();
+    const log = (
+      level: "info" | "warn" | "error",
+      fields: Record<string, unknown>,
+    ): void => {
+      deps.logger[level](
+        {
+          hostId,
+          providerId,
+          scope: scopeKey === "" ? "host" : "workspace",
+          durationMs: now - refresh.startedAt,
+          ...fields,
+        },
+        "Provider model catalog refresh settled",
+      );
+    };
+    if (entry.refresh !== refresh) {
+      log("info", { outcome: "superseded", changed: false });
+      return;
+    }
+    entry.refresh = null;
+    const before = pickerView(entry, refresh.fingerprint);
+    let level: "info" | "warn" | "error" = "info";
+    let fields: Record<string, unknown>;
+    if (settlement.ok) {
+      entry.good = {
+        fingerprint: refresh.fingerprint,
+        models: settlement.models,
+        selectedOnlyModels: settlement.selectedOnlyModels,
+        modelsJson: JSON.stringify(settlement.models),
+        selectedOnlyModelsJson: JSON.stringify(settlement.selectedOnlyModels),
+        fetchedAt: refresh.markedStale ? 0 : now,
+      };
+      entry.failure = null;
+      persistGood(deps, entry.key, entry.good);
+      fields = {
+        outcome: "success",
+        modelCount:
+          settlement.models.length + settlement.selectedOnlyModels.length,
+      };
+    } else {
+      const { error } = settlement;
+      const errorFields =
+        error instanceof ApiError
+          ? expectedFallbackErrorLogFields(error)
+          : runtimeErrorLogFields(deps.config, error);
+      if (
+        isHostUnavailableApiError(error) ||
+        refresh.sessionId !== deps.hub.getDaemonSessionIdForHost(hostId)
+      ) {
+        log("info", {
+          outcome: "host_unavailable",
+          changed: false,
+          ...errorFields,
+        });
+        return;
+      }
+      const code =
+        error instanceof ApiError &&
+        (error.status === 502 || error.status === 504)
+          ? toProviderModelCatalogFailureCode(error)
+          : null;
+      entry.failure = {
+        fingerprint: refresh.fingerprint,
+        code: code ?? "failed",
+        failedAt: now,
+      };
+      level = code === null ? "error" : "warn";
+      fields = { outcome: code ?? "failed", ...errorFields };
+    }
+    const changed = before !== pickerView(entry, refresh.fingerprint);
+    if (changed) {
+      schedulePush(deps, hostId);
+    }
+    log(level, { ...fields, changed });
+  }
+
+  function startRefresh(
+    deps: WorkSessionDeps,
+    entry: CatalogEntry,
+    fingerprint: string,
+    bridgeLaunch: HostDaemonBridgeLaunch,
+  ): Promise<void> {
+    const { hostId, providerId, scopeKey } = entry.key;
+    const refresh: CatalogRefresh = {
+      fingerprint,
+      sessionId: deps.hub.getDaemonSessionIdForHost(hostId),
+      startedAt: options.now(),
+      markedStale: false,
+      promise: Promise.resolve(),
+    };
+    entry.refresh = refresh;
+    refresh.promise = callHostOnlineRpc(deps, {
+      hostId,
+      timeoutMs: COMMAND_TIMEOUT_MS,
+      command: {
+        type: "provider.list_models",
+        providerId,
+        ...(scopeKey === "" ? {} : { cwd: scopeKey }),
+        bridgeLaunch,
+      },
+    }).then(
+      (result) =>
+        settle(deps, entry, refresh, {
+          ok: true,
+          models: result.models,
+          selectedOnlyModels: result.selectedOnlyModels,
+        }),
+      (error: unknown) => settle(deps, entry, refresh, { ok: false, error }),
+    );
+    return refresh.promise;
+  }
+
+  function joinOrStartRefresh(
+    deps: WorkSessionDeps,
+    entry: CatalogEntry,
+    fingerprint: string,
+    bridgeLaunch: HostDaemonBridgeLaunch,
+  ): Promise<void> {
+    return entry.refresh?.fingerprint === fingerprint
+      ? entry.refresh.promise
+      : startRefresh(deps, entry, fingerprint, bridgeLaunch);
+  }
+
+  return {
+    async read(deps, args) {
+      const bridgeLaunch = requireBridgeLaunchForProviderId(
+        deps,
+        args.provider.id,
+      );
+      const fingerprint = catalogFingerprint(args.provider.id, bridgeLaunch);
+      const entry = loadEntry(deps, {
+        hostId: args.hostId,
+        providerId: args.provider.id,
+        scopeKey:
+          args.cwd !== null &&
+          providerModelCatalogDependsOnWorkspace(
+            args.provider.capabilities.modelCatalogScope,
+          )
+            ? args.cwd
+            : "",
+      });
+      for (let refreshed = false; ; refreshed = true) {
+        const decision = evaluate(
+          entry,
+          fingerprint,
+          args.access,
+          options.now(),
+          refreshed,
+        );
+        if (decision.kind === "serve") {
+          if (decision.backgroundRefresh) {
+            void joinOrStartRefresh(deps, entry, fingerprint, bridgeLaunch);
+          }
+          return decision.result;
+        }
+        await joinOrStartRefresh(deps, entry, fingerprint, bridgeLaunch);
+      }
+    },
+
+    async refreshForPrewarm(deps, args) {
+      const bridgeLaunch = resolveBridgeLaunchForProviderId(
+        deps,
+        args.provider.id,
+      );
+      if (bridgeLaunch === null) {
+        return;
+      }
+      const fingerprint = catalogFingerprint(args.provider.id, bridgeLaunch);
+      const entry = loadEntry(deps, {
+        hostId: args.hostId,
+        providerId: args.provider.id,
+        scopeKey: "",
+      });
+      if (entry.refresh?.fingerprint === fingerprint) {
+        return;
+      }
+      const { good, failure } = currentState(entry, fingerprint);
+      const lastAttemptAt = Math.max(
+        good?.fetchedAt ?? Number.NEGATIVE_INFINITY,
+        failure?.failedAt ?? Number.NEGATIVE_INFINITY,
+      );
+      if (options.now() - lastAttemptAt < PREWARM_MIN_AGE_MS) {
+        return;
+      }
+      await startRefresh(deps, entry, fingerprint, bridgeLaunch);
+    },
+
+    clearFailure(hostId, providerId) {
+      for (const entry of entries.values()) {
+        if (
+          entry.key.hostId === hostId &&
+          entry.key.providerId === providerId
+        ) {
+          entry.failure = null;
+        }
+      }
+    },
+
+    markAllStale() {
+      for (const entry of entries.values()) {
+        entry.failure = null;
+        if (entry.good !== null) {
+          entry.good.fetchedAt = 0;
+        }
+        if (entry.refresh !== null) {
+          entry.refresh.markedStale = true;
+        }
+      }
+    },
+
+    forgetHost(deps, hostId) {
+      for (const [mapKey, entry] of entries) {
+        if (entry.key.hostId === hostId) {
+          entry.refresh = null;
+          entries.delete(mapKey);
+        }
+      }
+      const timer = pendingPushByHost.get(hostId);
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        pendingPushByHost.delete(hostId);
+      }
+      deleteStoredProviderModelCatalogsForHost(deps.db, hostId);
+    },
+  };
+}

--- a/apps/server/src/services/providers/provider-registry.ts
+++ b/apps/server/src/services/providers/provider-registry.ts
@@ -62,10 +62,11 @@ export interface ProviderRegistryService {
   get(providerId: string): ProviderRegistration | null;
   getRegistrationRevision(): number;
   lookupInstalled(key: ProviderHealthCacheKey): Promise<boolean> | undefined;
-  rememberInstalled(
+  rememberInstalled(key: ProviderHealthCacheKey, value: Promise<boolean>): void;
+  revalidateInstalled(
     key: ProviderHealthCacheKey,
-    value: Promise<boolean>,
-  ): void;
+    probe: () => Promise<boolean>,
+  ): Promise<void>;
   forgetInstalledKey(key: ProviderHealthCacheKey): void;
   forgetAllInstalled(): void;
   getServerCapabilities(providerId: string): ProviderServerCapabilities | null;
@@ -116,6 +117,7 @@ export function createProviderRegistryService(
         registrationRevision: number;
         expiresAt: number;
         value: Promise<boolean>;
+        revalidating: boolean;
       }
     >
   >();
@@ -188,7 +190,7 @@ export function createProviderRegistryService(
     clearTimeout(timer);
   }
 
-  return {
+  const service: ProviderRegistryService = {
     list() {
       const entries = [...pluginRegistrations.values()].sort(
         compareInstallRank,
@@ -223,19 +225,7 @@ export function createProviderRegistryService(
     },
 
     lookupInstalled(key) {
-      const hostEntries = installedByHostId.get(key.hostId);
-      if (hostEntries === undefined) return undefined;
-      const entry = hostEntries.get(key.providerId);
-      if (entry === undefined) return undefined;
-      if (
-        entry.registrationRevision !== registrationRevision ||
-        entry.expiresAt <= Date.now()
-      ) {
-        hostEntries.delete(key.providerId);
-        if (hostEntries.size === 0) installedByHostId.delete(key.hostId);
-        return undefined;
-      }
-      return entry.value;
+      return installedByHostId.get(key.hostId)?.get(key.providerId)?.value;
     },
 
     rememberInstalled(key, value) {
@@ -248,7 +238,35 @@ export function createProviderRegistryService(
         registrationRevision,
         expiresAt: Date.now() + PROVIDER_INSTALLED_CACHE_TTL_MS,
         value,
+        revalidating: false,
       });
+    },
+
+    revalidateInstalled(key, probe) {
+      const entry = installedByHostId.get(key.hostId)?.get(key.providerId);
+      if (
+        entry === undefined ||
+        entry.revalidating ||
+        (entry.registrationRevision === registrationRevision &&
+          entry.expiresAt > Date.now())
+      ) {
+        return Promise.resolve();
+      }
+      entry.revalidating = true;
+      const isCurrent = () =>
+        installedByHostId.get(key.hostId)?.get(key.providerId) === entry;
+      return probe().then(
+        (installed) => {
+          if (isCurrent()) {
+            service.rememberInstalled(key, Promise.resolve(installed));
+          }
+        },
+        () => {
+          if (isCurrent()) {
+            service.forgetInstalledKey(key);
+          }
+        },
+      );
     },
 
     forgetInstalledKey(key) {
@@ -363,4 +381,5 @@ export function createProviderRegistryService(
       releaseAllProviderRegistrationWaiters();
     },
   };
+  return service;
 }

--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -7,16 +7,12 @@ import type {
 } from "@bb/server-contract";
 import { type CustomProviderModel } from "@bb/config/bb-app-managed-config";
 import {
-  providerModelCatalogDependsOnWorkspace,
   reasoningEffortsForLevels,
   type AvailableModel,
   type ProviderInfo,
 } from "@bb/domain";
 import { getAppSettings } from "@bb/db";
-import { type HostDaemonRetryableOnlineRpcCommand } from "@bb/host-daemon-contract";
-import type { ProviderModelListMemoValue } from "../../lifecycle-dedupers.js";
 import type { LoggedWorkSessionDeps } from "../../types.js";
-import { COMMAND_TIMEOUT_MS } from "../../constants.js";
 import { ApiError } from "../../errors.js";
 import { callHostRetryableOnlineRpc } from "../hosts/online-rpc.js";
 import { getHostPermissionCeiling } from "../hosts/permission-ceiling.js";
@@ -24,18 +20,23 @@ import {
   requireConnectedHostSession,
   requireEnvironment,
 } from "../lib/entity-lookup.js";
+import { expectedFallbackErrorLogFields } from "../lib/error-log-fields.js";
 import { isSuspendedHostUnavailableError } from "../lib/lifecycle-api-errors.js";
-import { createProviderListingBudget } from "../providers/native-roots.js";
+import {
+  createProviderListingBudget,
+  type ProviderListingBudget,
+} from "../providers/native-roots.js";
+import {
+  toProviderModelCatalogFailureCode,
+  type ProviderModelCatalogAccess,
+} from "../providers/provider-model-catalog-store.js";
 import type {
   ProviderHealthCacheKey,
   ProviderRegistryService,
 } from "../providers/provider-registry.js";
 import { getSupportedReasoningLevelsForProvider } from "../threads/thread-reasoning-policy.js";
 import { resolveSystemLookupHostId } from "./host-lookup.js";
-import {
-  requireBridgeLaunchForProviderId,
-  resolveBridgeLaunchForProviderId,
-} from "./provider-bridge-launch.js";
+import { resolveBridgeLaunchForProviderId } from "./provider-bridge-launch.js";
 import { mapProviderMaintenanceRequests } from "./provider-maintenance-concurrency.js";
 
 type SystemExecutionOptionsRequest = SystemExecutionOptionsQuery;
@@ -49,14 +50,6 @@ interface ResolveSystemProviderModelsArgs {
   cwd?: string;
   hostId: string;
   providerId: string;
-}
-
-interface ExpectedFallbackErrorLogFields {
-  errorCode: string;
-  errorDetails?: unknown;
-  errorMessage: string;
-  errorRetryable?: boolean;
-  errorStatus: number;
 }
 
 type ModelListResult = Pick<
@@ -149,23 +142,6 @@ function canOmitProviderDiscoveryForError(error: unknown): error is ApiError {
   );
 }
 
-function expectedFallbackErrorLogFields(
-  error: ApiError,
-): ExpectedFallbackErrorLogFields {
-  const fields: ExpectedFallbackErrorLogFields = {
-    errorCode: error.body.code,
-    errorMessage: error.body.message,
-    errorStatus: error.status,
-  };
-  if (error.body.details !== undefined) {
-    fields.errorDetails = error.body.details;
-  }
-  if (error.body.retryable !== undefined) {
-    fields.errorRetryable = error.body.retryable;
-  }
-  return fields;
-}
-
 async function listInstalledPluginProviderInfos(
   deps: LoggedWorkSessionDeps,
   hostId: string,
@@ -191,24 +167,27 @@ async function listInstalledPluginProviderInfos(
         hostId,
         providerId: registration.info.id,
       };
+      const probe = async (probeBudget: ProviderListingBudget) => {
+        const result = await callHostRetryableOnlineRpc(deps, {
+          hostId,
+          timeoutMs: probeBudget.remainingMs(),
+          command: {
+            type: "provider.health",
+            providerId: registration.info.id,
+            bridgeLaunch,
+          },
+        });
+        return result.supported && result.health.status !== "not_installed";
+      };
       const cached = deps.providerRegistry.lookupInstalled(cacheKey);
       try {
-        const installed =
-          cached ??
-          (async () => {
-            const result = await callHostRetryableOnlineRpc(deps, {
-              hostId,
-              timeoutMs: budget.remainingMs(),
-              command: {
-                type: "provider.health",
-                providerId: registration.info.id,
-                bridgeLaunch,
-              },
-            });
-            return result.supported && result.health.status !== "not_installed";
-          })();
+        const installed = cached ?? probe(budget);
         if (cached === undefined) {
           deps.providerRegistry.rememberInstalled(cacheKey, installed);
+        } else {
+          void deps.providerRegistry.revalidateInstalled(cacheKey, () =>
+            probe(createProviderListingBudget()),
+          );
         }
         return (await installed) ? registration.info : null;
       } catch (error) {
@@ -235,7 +214,7 @@ async function listInstalledPluginProviderInfos(
   );
 }
 
-async function listSystemProviderInfosForHost(
+export async function listSystemProviderInfosForHost(
   deps: LoggedWorkSessionDeps,
   hostId: string,
   capability?: ProviderCapabilityFilter,
@@ -319,9 +298,10 @@ export async function resolveSystemProviderModels(
   }
 
   const result = await loadSystemProviderModels(deps, {
-    ...(args.cwd !== undefined ? { cwd: args.cwd } : {}),
+    cwd: args.cwd ?? null,
     hostId: args.hostId,
     provider,
+    access: { kind: "validation", requiredModel: null },
   });
   const { models, selectedOnlyModels } = appendCustomModels(
     deps.providerRegistry,
@@ -412,9 +392,28 @@ export function appendCustomModels(
   };
 }
 
-export async function resolveSystemExecutionOptions(
+export function resolveSystemExecutionOptions(
   deps: LoggedWorkSessionDeps,
   query: SystemExecutionOptionsRequest,
+): Promise<SystemExecutionOptionsResponse> {
+  return resolveExecutionOptions(deps, query, { kind: "picker" });
+}
+
+export function resolveSystemExecutionOptionsForValidation(
+  deps: LoggedWorkSessionDeps,
+  query: SystemExecutionOptionsRequest,
+  requiredModel: string | null,
+): Promise<SystemExecutionOptionsResponse> {
+  return resolveExecutionOptions(deps, query, {
+    kind: "validation",
+    requiredModel,
+  });
+}
+
+async function resolveExecutionOptions(
+  deps: LoggedWorkSessionDeps,
+  query: SystemExecutionOptionsRequest,
+  access: ProviderModelCatalogAccess,
 ): Promise<SystemExecutionOptionsResponse> {
   if (query.providerId === undefined) {
     await deps.providerRegistry.whenRegistrationsSettled();
@@ -437,9 +436,10 @@ export async function resolveSystemExecutionOptions(
   const earlyModelResultPromise =
     hostId !== null && configuredRequestedProvider
       ? loadSystemProviderModels(deps, {
-          ...(cwd !== undefined ? { cwd } : {}),
+          cwd: cwd ?? null,
           hostId,
           provider: configuredRequestedProvider,
+          access,
         })
       : null;
   let providers: ProviderInfo[];
@@ -511,9 +511,10 @@ export async function resolveSystemExecutionOptions(
     earlyModelResultPromise !== null
       ? await earlyModelResultPromise
       : await loadSystemProviderModels(deps, {
-          ...(cwd !== undefined ? { cwd } : {}),
+          cwd: cwd ?? null,
           hostId,
           provider: modelsProvider,
+          access,
         });
 
   const { models, selectedOnlyModels } = appendCustomModels(
@@ -537,97 +538,35 @@ export async function resolveSystemExecutionOptions(
 
 async function loadSystemProviderModels(
   deps: LoggedWorkSessionDeps,
-  {
-    cwd,
-    hostId,
-    provider,
-  }: {
-    cwd?: string;
+  args: {
+    cwd: string | null;
     hostId: string;
     provider: ProviderInfo;
+    access: ProviderModelCatalogAccess;
   },
 ): Promise<ModelListResult> {
-  if (!provider.available) {
-    return unavailableProviderModelResult(provider.id);
+  if (!args.provider.available) {
+    return unavailableProviderModelResult(args.provider.id);
   }
-  const bridgeLaunch = requireBridgeLaunchForProviderId(deps, provider.id);
-  const command: ProviderListModelsCommand = {
-    type: "provider.list_models",
-    providerId: provider.id,
-    ...(cwd !== undefined &&
-    providerModelCatalogDependsOnWorkspace(
-      provider.capabilities.modelCatalogScope,
-    )
-      ? { cwd }
-      : {}),
-    bridgeLaunch,
-  };
-  try {
-    const { models, selectedOnlyModels } = await listProviderModelsMemoized(
-      deps,
-      { command, hostId },
-    );
+  const result = await deps.lifecycleDedupers.providerModelCatalogs.read(
+    deps,
+    args,
+  );
+  if (result.kind === "catalog") {
     return {
-      models,
-      selectedOnlyModels,
+      models: result.models,
+      selectedOnlyModels: result.selectedOnlyModels,
       modelLoadError: null,
     };
-  } catch (error) {
-    if (
-      !(error instanceof ApiError) ||
-      (error.status !== 502 && error.status !== 504)
-    ) {
-      throw error;
-    }
-    deps.logger.warn(
-      {
-        ...expectedFallbackErrorLogFields(error),
-        hostId,
-        providerId: provider.id,
-      },
-      "Failed to resolve provider models",
-    );
-    const modelLoadError = buildModelLoadError({
-      error,
-      provider,
-    });
-    return {
-      models: listFallbackModelsForLoadError(deps, {
-        code: modelLoadError.code,
-        providerId: provider.id,
-      }),
-      selectedOnlyModels: [],
-      modelLoadError,
-    };
   }
-}
-
-type ProviderListModelsCommand = Extract<
-  HostDaemonRetryableOnlineRpcCommand,
-  { type: "provider.list_models" }
->;
-
-async function listProviderModelsMemoized(
-  deps: LoggedWorkSessionDeps,
-  { command, hostId }: { command: ProviderListModelsCommand; hostId: string },
-): Promise<ProviderModelListMemoValue> {
-  const probe = (): Promise<ProviderModelListMemoValue> =>
-    callHostRetryableOnlineRpc(deps, {
-      hostId,
-      timeoutMs: COMMAND_TIMEOUT_MS,
-      command,
-    });
-  const daemonSessionId = deps.hub.getDaemonSessionIdForHost(hostId);
-  if (daemonSessionId === null) {
-    return probe();
-  }
-  const memoKey = JSON.stringify([
-    hostId,
-    daemonSessionId,
-    deps.providerRegistry.getRegistrationRevision(),
-    command,
-  ]);
-  return deps.lifecycleDedupers.providerModelList.run(memoKey, probe);
+  return {
+    models: listFallbackModelsForLoadError(deps, {
+      code: result.code,
+      providerId: args.provider.id,
+    }),
+    selectedOnlyModels: [],
+    modelLoadError: { providerId: args.provider.id, code: result.code },
+  };
 }
 
 function listFallbackModelsForLoadError(
@@ -658,24 +597,6 @@ function buildModelLoadError({
 }: BuildModelLoadErrorArgs): SystemExecutionOptionsModelLoadError {
   return {
     providerId: provider.id,
-    code: toModelLoadErrorCode(error),
+    code: toProviderModelCatalogFailureCode(error),
   };
-}
-
-function toModelLoadErrorCode(
-  error: ApiError,
-): SystemExecutionOptionsModelLoadErrorCode {
-  if (error.body.code === "command_timeout") {
-    return "timeout";
-  }
-
-  if (error.body.code === "missing_executable") {
-    return "missing_executable";
-  }
-
-  if (error.body.code === "auth_required") {
-    return "auth_required";
-  }
-
-  return "failed";
 }

--- a/apps/server/src/services/threads/thread-execution-override.ts
+++ b/apps/server/src/services/threads/thread-execution-override.ts
@@ -14,7 +14,7 @@ import {
 import { ApiError } from "../../errors.js";
 import type { LoggedWorkSessionDeps } from "../../types.js";
 import type { ProviderRegistryService } from "../providers/provider-registry.js";
-import { resolveSystemExecutionOptions } from "../system/execution-options.js";
+import { resolveSystemExecutionOptionsForValidation } from "../system/execution-options.js";
 import { getLastExecutionOptions } from "./thread-events.js";
 import { getSupportedReasoningLevelsForProvider } from "./thread-reasoning-policy.js";
 
@@ -118,7 +118,11 @@ export async function applyThreadExecutionOverride(
 ): Promise<void> {
   const { thread, patch } = args;
 
-  const models = await loadThreadProviderModels(deps, thread);
+  const models = await loadThreadProviderModels(
+    deps,
+    thread,
+    typeof patch.model === "string" ? patch.model : null,
+  );
   const existing = getThreadExecutionOverride(deps.db, thread.id) ?? {
     modelOverride: null,
     reasoningLevelOverride: null,
@@ -172,13 +176,18 @@ export async function recoverThreadModelOverride(
 async function loadThreadProviderModels(
   deps: LoggedWorkSessionDeps,
   thread: Thread,
+  requiredModel: string | null,
 ): Promise<readonly AvailableModel[]> {
-  const result = await resolveSystemExecutionOptions(deps, {
-    providerId: thread.providerId,
-    ...(thread.environmentId !== null
-      ? { environmentId: thread.environmentId }
-      : {}),
-  });
+  const result = await resolveSystemExecutionOptionsForValidation(
+    deps,
+    {
+      providerId: thread.providerId,
+      ...(thread.environmentId !== null
+        ? { environmentId: thread.environmentId }
+        : {}),
+    },
+    requiredModel,
+  );
   if (result.modelLoadError !== null) {
     throw new ApiError(
       503,

--- a/apps/server/src/start-server.ts
+++ b/apps/server/src/start-server.ts
@@ -23,6 +23,7 @@ import {
   runPeriodicSweeps,
   runStartupRecoverySweep,
 } from "./services/system/periodic-sweeps.js";
+import { installProviderModelCatalogPrewarm } from "./services/providers/provider-model-catalog-prewarm.js";
 import { createProviderRegistryService } from "./services/providers/provider-registry.js";
 import { createTelemetryService } from "./services/system/telemetry.js";
 import { TerminalSessionLifecycle } from "./services/terminals/terminal-session-lifecycle.js";
@@ -206,6 +207,8 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
     telemetry,
     terminalSessions,
   };
+  const providerModelCatalogPrewarm =
+    installProviderModelCatalogPrewarm(sweepDeps);
   await runStartupRecoverySweep(sweepDeps).catch((error) => {
     logger.error({ err: error }, "Startup recovery sweep failed");
   });
@@ -258,6 +261,7 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
       return shutdownPromise;
     }
     shutdownPromise = (async () => {
+      providerModelCatalogPrewarm.stop();
       eventLoopStallMonitor.stop();
       clearInterval(sweepInterval);
       pluginCatalogService.stopPeriodicRefresh();

--- a/apps/server/test/helpers/provider-model-catalogs.ts
+++ b/apps/server/test/helpers/provider-model-catalogs.ts
@@ -1,0 +1,107 @@
+import type { AvailableModel } from "@bb/domain";
+import { vi } from "vitest";
+import {
+  createProviderModelCatalogStore,
+  type ProviderModelCatalogStore,
+} from "../../src/services/providers/provider-model-catalog-store.js";
+import type { ProviderRegistration } from "../../src/services/providers/provider-registry.js";
+import { availableModelFixture } from "./available-models.js";
+import type { HostRpcHandlerResult } from "./host-rpc.js";
+import type { TestAppHarness } from "./test-app.js";
+
+export function installCatalogStore(
+  harness: TestAppHarness,
+  args: { clock: { now: number }; memoryEntryLimit?: number },
+): ProviderModelCatalogStore {
+  const store = createProviderModelCatalogStore({
+    now: () => args.clock.now,
+    pushCoalesceMs: 0,
+    memoryEntryLimit: args.memoryEntryLimit ?? 256,
+  });
+  harness.deps.lifecycleDedupers.providerModelCatalogs = store;
+  return store;
+}
+
+export function modelList(...modelIds: string[]): AvailableModel[] {
+  return modelIds.map((model) => availableModelFixture({ model }));
+}
+
+export function catalogAnswer(
+  models: AvailableModel[],
+  selectedOnlyModels: AvailableModel[] = [],
+): HostRpcHandlerResult {
+  return { ok: true, result: { models, selectedOnlyModels } };
+}
+
+export function errorAnswer(errorCode: string): HostRpcHandlerResult {
+  return { ok: false, errorCode, errorMessage: `model list ${errorCode}` };
+}
+
+export function healthAnswer(
+  status: "ready" | "not_installed",
+): HostRpcHandlerResult {
+  return {
+    ok: true,
+    result: {
+      supported: true,
+      health: {
+        status,
+        statusMessage: null,
+        accountEmail: null,
+        planLabel: null,
+        installedVersion: null,
+        minimumSupportedVersion: null,
+        canInstall: false,
+        canUpdate: false,
+        loginCommand: null,
+      },
+    },
+  };
+}
+
+export function requireRegistration(
+  harness: TestAppHarness,
+  providerId: string,
+): ProviderRegistration {
+  const registration = harness.deps.providerRegistry.get(providerId);
+  if (registration === null) {
+    throw new Error(`Missing provider registration ${providerId}`);
+  }
+  return registration;
+}
+
+export function capturePushes(harness: TestAppHarness): string[] {
+  const hostIds: string[] = [];
+  harness.hub.onChangedMessage((message) => {
+    if (
+      message.entity === "host" &&
+      message.changes.includes("provider-model-catalog-changed")
+    ) {
+      hostIds.push(message.id);
+    }
+  });
+  return hostIds;
+}
+
+export function captureLogLines(harness: TestAppHarness) {
+  const info = vi.fn();
+  const warn = vi.fn();
+  const error = vi.fn();
+  harness.deps.logger = { ...harness.deps.logger, info, warn, error };
+  return (message: string) =>
+    (
+      [
+        ["info", info],
+        ["warn", warn],
+        ["error", error],
+      ] as const
+    ).flatMap(([level, log]) =>
+      log.mock.calls.flatMap(([fields, logged]) =>
+        logged === message ? [{ level, ...fields }] : [],
+      ),
+    );
+}
+
+export function settleTimers(ms = 20): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/server/test/providers/provider-model-catalog-prewarm.test.ts
+++ b/apps/server/test/providers/provider-model-catalog-prewarm.test.ts
@@ -1,0 +1,557 @@
+import { openSession, updateHost } from "@bb/db";
+import type { JsonValue } from "@bb/domain";
+import {
+  HOST_DAEMON_PROTOCOL_VERSION,
+  type HostDaemonOnlineRpcRequestMessage,
+} from "@bb/host-daemon-contract";
+import { createDeferredPromise } from "@bb/test-helpers";
+import { describe, expect, it, vi } from "vitest";
+import { handleDaemonSocketClosed } from "../../src/internal/session-owner-side-effects.js";
+import { installProviderModelCatalogPrewarm } from "../../src/services/providers/provider-model-catalog-prewarm.js";
+import { createProviderRegistryService } from "../../src/services/providers/provider-registry.js";
+import { resolveSystemExecutionOptions } from "../../src/services/system/execution-options.js";
+import {
+  registerHostRpcResponder,
+  type HostRpcHandlerResult,
+} from "../helpers/host-rpc.js";
+import {
+  captureLogLines,
+  catalogAnswer,
+  errorAnswer,
+  healthAnswer,
+  installCatalogStore,
+  modelList,
+  requireRegistration,
+  settleTimers,
+} from "../helpers/provider-model-catalogs.js";
+import { registerFirstPartyProviders } from "../helpers/provider-registry.js";
+import { seedHost, seedSession } from "../helpers/seed.js";
+import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
+
+const BASE_NOW = 1_800_000_000_000;
+const HOUR = 60 * 60_000;
+const PASS_FINISHED = "Provider model catalog prewarm pass finished";
+const ALWAYS_VISIBLE_PROVIDER_IDS = [
+  "acp-cursor",
+  "claude-code",
+  "codex",
+  "pi",
+];
+
+type RpcCommand = HostDaemonOnlineRpcRequestMessage["command"];
+type ListModelsCommand = Extract<RpcCommand, { type: "provider.list_models" }>;
+type HealthCommand = Extract<RpcCommand, { type: "provider.health" }>;
+type RpcAnswer<TCommand> = (
+  command: TCommand,
+  hostId: string,
+) => HostRpcHandlerResult | Promise<HostRpcHandlerResult>;
+type LogLines = ReturnType<typeof captureLogLines>;
+
+interface DaemonHost {
+  hostId: string;
+  sessionId: string;
+}
+
+async function withPrewarm(
+  harness: TestAppHarness,
+  run: () => Promise<void>,
+): Promise<void> {
+  const prewarm = installProviderModelCatalogPrewarm(harness.deps);
+  try {
+    await run();
+  } finally {
+    prewarm.stop();
+  }
+}
+
+async function waitForPasses(logLines: LogLines, count: number) {
+  await vi.waitFor(() => {
+    expect(logLines(PASS_FINISHED)).toHaveLength(count);
+  });
+}
+
+function openDaemonSession(harness: TestAppHarness, hostId: string): string {
+  return openSession(harness.db, {
+    hostId,
+    instanceId: `instance-${hostId}`,
+    hostName: "Test Host",
+    dataDir: `/tmp/bb-host-data/${hostId}`,
+    protocolVersion: HOST_DAEMON_PROTOCOL_VERSION,
+    heartbeatIntervalMs: 5_000,
+    leaseTimeoutMs: 30_000,
+  }).id;
+}
+
+function seedDaemonHost(harness: TestAppHarness, hostId: string): DaemonHost {
+  const host = seedHost(harness.deps, { id: hostId });
+  return { hostId: host.id, sessionId: openDaemonSession(harness, host.id) };
+}
+
+function registerResponder(
+  harness: TestAppHarness,
+  args: DaemonHost & {
+    health?: RpcAnswer<HealthCommand>;
+    listModels?: RpcAnswer<ListModelsCommand>;
+  },
+) {
+  const { requests } = registerHostRpcResponder(harness, {
+    hostId: args.hostId,
+    sessionId: args.sessionId,
+    handle: ({ command }) => {
+      switch (command.type) {
+        case "provider.health":
+          return (
+            args.health?.(command, args.hostId) ?? healthAnswer("not_installed")
+          );
+        case "provider.list_models":
+          return (
+            args.listModels?.(command, args.hostId) ??
+            catalogAnswer(modelList(`${command.providerId}-model`))
+          );
+        default:
+          throw new Error(`Unexpected RPC command ${command.type}`);
+      }
+    },
+  });
+  const listRequests = () =>
+    requests.flatMap(({ command }) =>
+      command.type === "provider.list_models" ? [command] : [],
+    );
+  return {
+    ...args,
+    get commands() {
+      return requests.map(({ command }) => command);
+    },
+    listRequests,
+    listedProviderIds: () =>
+      listRequests()
+        .map((command) => command.providerId)
+        .sort(),
+  };
+}
+
+function createHold() {
+  const outstanding: { hostId: string; release(): void }[] = [];
+  const maxByHost = new Map<string, number>();
+  let maxOutstanding = 0;
+  return {
+    outstanding,
+    maxOutstanding: () => maxOutstanding,
+    maxOutstandingForHost: (hostId: string) => maxByHost.get(hostId) ?? 0,
+    answer(hostId: string): Promise<HostRpcHandlerResult> {
+      const deferred = createDeferredPromise<HostRpcHandlerResult>();
+      const held = {
+        hostId,
+        release() {
+          outstanding.splice(outstanding.indexOf(held), 1);
+          deferred.resolve(catalogAnswer(modelList("held-model")));
+        },
+      };
+      outstanding.push(held);
+      maxOutstanding = Math.max(maxOutstanding, outstanding.length);
+      maxByHost.set(
+        hostId,
+        Math.max(
+          maxByHost.get(hostId) ?? 0,
+          outstanding.filter((entry) => entry.hostId === hostId).length,
+        ),
+      );
+      return deferred.promise;
+    },
+  };
+}
+
+async function releaseHeldOneByOne(
+  hold: ReturnType<typeof createHold>,
+  count: number,
+): Promise<void> {
+  for (let released = 0; released < count; released += 1) {
+    await vi.waitFor(() => {
+      expect(hold.outstanding.length).toBeGreaterThan(0);
+    });
+    await settleTimers();
+    hold.outstanding[0]?.release();
+  }
+}
+
+function registerClone(
+  harness: TestAppHarness,
+  args: {
+    id: string;
+    available?: boolean;
+    bridgeOptions?: Readonly<Record<string, JsonValue>>;
+    pluginId?: string;
+  },
+) {
+  const base = requireRegistration(harness, "claude-code");
+  const pluginId = args.pluginId ?? base.pluginId;
+  return harness.deps.providerRegistry.register({
+    ...base,
+    pluginId,
+    bridgeOptions: args.bridgeOptions ?? base.bridgeOptions,
+    info: {
+      ...base.info,
+      id: args.id,
+      pluginId,
+      available: args.available ?? base.info.available,
+    },
+  });
+}
+
+describe("provider model catalog prewarm", () => {
+  it("warms available always-visible providers and the installed-only provider the listing finds, once each without a cwd", async () => {
+    await withTestHarness(async (harness) => {
+      installCatalogStore(harness, { clock: { now: BASE_NOW } });
+      const logLines = captureLogLines(harness);
+      registerClone(harness, { id: "catalog-unavailable", available: false });
+      registerClone(harness, {
+        id: "catalog-bridgeless",
+        pluginId: "catalog-no-artifact",
+      });
+      expect(requireRegistration(harness, "acp-opencode").visibility).toBe(
+        "installed",
+      );
+      const host = seedDaemonHost(harness, "host-prewarm-scope");
+
+      await withPrewarm(harness, async () => {
+        const responder = registerResponder(harness, {
+          ...host,
+          health: (command) =>
+            healthAnswer(
+              command.providerId === "acp-opencode" ? "ready" : "not_installed",
+            ),
+        });
+        await waitForPasses(logLines, 1);
+
+        expect(responder.listedProviderIds()).toEqual(
+          [...ALWAYS_VISIBLE_PROVIDER_IDS, "acp-opencode"].sort(),
+        );
+        expect(
+          responder.listRequests().filter((command) => "cwd" in command),
+        ).toEqual([]);
+        expect(
+          responder.commands.filter(
+            (command) =>
+              "providerId" in command &&
+              command.providerId.startsWith("catalog-"),
+          ),
+        ).toEqual([]);
+      });
+    });
+  });
+
+  it("refreshes only missing, re-fingerprinted or at least four hours old catalogs on connect and on a registrations change, and skips a recent failure", async () => {
+    await withTestHarness(async (harness) => {
+      const clock = { now: BASE_NOW - 5 * HOUR };
+      installCatalogStore(harness, { clock });
+      const logLines = captureLogLines(harness);
+      const base = requireRegistration(harness, "claude-code");
+      const reregisterProbe = (version: string) =>
+        registerClone(harness, {
+          id: "catalog-probe",
+          bridgeOptions: { ...base.bridgeOptions, catalogProbe: version },
+        });
+      let probe = reregisterProbe("one");
+      const host = seedDaemonHost(harness, "host-prewarm-age");
+      const responder = registerResponder(harness, {
+        ...host,
+        listModels: (command) =>
+          command.providerId === "acp-cursor"
+            ? errorAnswer("command_failed")
+            : catalogAnswer(modelList(`${command.providerId}-model`)),
+      });
+      const read = (providerId: string) =>
+        resolveSystemExecutionOptions(harness.deps, {
+          hostId: host.hostId,
+          providerId,
+        });
+      await read("claude-code");
+      clock.now = BASE_NOW - HOUR;
+      for (const providerId of ["codex", "acp-cursor", "catalog-probe"]) {
+        await read(providerId);
+      }
+      probe.dispose();
+      probe = reregisterProbe("two");
+      clock.now = BASE_NOW;
+      const readCount = responder.listRequests().length;
+      const prewarmed = () =>
+        responder
+          .listRequests()
+          .slice(readCount)
+          .map((command) => command.providerId)
+          .sort();
+
+      await withPrewarm(harness, async () => {
+        await waitForPasses(logLines, 1);
+        expect(prewarmed()).toEqual(["catalog-probe", "claude-code", "pi"]);
+
+        clock.now += HOUR;
+        probe.dispose();
+        reregisterProbe("three");
+        harness.hub.notifySystem(["provider-registrations-changed"]);
+        await waitForPasses(logLines, 2);
+        expect(prewarmed()).toEqual([
+          "catalog-probe",
+          "catalog-probe",
+          "claude-code",
+          "pi",
+        ]);
+      });
+    });
+  });
+
+  it("limits list requests to two per host and four across hosts", async () => {
+    await withTestHarness(async (harness) => {
+      installCatalogStore(harness, { clock: { now: BASE_NOW } });
+      const logLines = captureLogLines(harness);
+      const hold = createHold();
+      const [single, ...others] = [
+        "host-prewarm-limit-single",
+        "host-prewarm-limit-a",
+        "host-prewarm-limit-b",
+        "host-prewarm-limit-c",
+      ].map((hostId) => seedDaemonHost(harness, hostId));
+      const connect = (host: DaemonHost) =>
+        registerResponder(harness, {
+          ...host,
+          listModels: (_command, routedHostId) => hold.answer(routedHostId),
+        });
+
+      await withPrewarm(harness, async () => {
+        const singleResponder = connect(single!);
+        await releaseHeldOneByOne(hold, ALWAYS_VISIBLE_PROVIDER_IDS.length);
+        await waitForPasses(logLines, 1);
+        expect(hold.maxOutstanding()).toBe(2);
+
+        const responders = others.map(connect);
+        await releaseHeldOneByOne(
+          hold,
+          responders.length * ALWAYS_VISIBLE_PROVIDER_IDS.length,
+        );
+        await waitForPasses(logLines, 4);
+
+        expect(hold.maxOutstanding()).toBe(4);
+        for (const responder of [singleResponder, ...responders]) {
+          expect(responder.listedProviderIds()).toEqual(
+            ALWAYS_VISIBLE_PROVIDER_IDS,
+          );
+          expect(hold.maxOutstandingForHost(responder.hostId)).toBe(2);
+        }
+      });
+    });
+  });
+
+  it("never requests the remaining providers after the host disconnects mid-pass and records no failure for the interrupted refreshes", async () => {
+    await withTestHarness(async (harness) => {
+      installCatalogStore(harness, { clock: { now: BASE_NOW } });
+      const logLines = captureLogLines(harness);
+      const hold = createHold();
+      const host = seedDaemonHost(harness, "host-prewarm-disconnect");
+      registerResponder(harness, {
+        ...host,
+        listModels: (_command, hostId) => hold.answer(hostId),
+      });
+      const hubRequests = vi.spyOn(harness.hub, "requestHostOnlineRpc");
+      const listAttempts = () =>
+        hubRequests.mock.calls.filter(
+          ([args]) => args.message.command.type === "provider.list_models",
+        ).length;
+
+      await withPrewarm(harness, async () => {
+        await vi.waitFor(() => {
+          expect(hold.outstanding).toHaveLength(2);
+        });
+        handleDaemonSocketClosed(harness.deps, { sessionId: host.sessionId });
+        await waitForPasses(logLines, 1);
+        await settleTimers();
+        expect(listAttempts()).toBe(2);
+
+        const next = registerResponder(harness, {
+          hostId: host.hostId,
+          sessionId: openDaemonSession(harness, host.hostId),
+        });
+        await waitForPasses(logLines, 2);
+        expect(next.listedProviderIds()).toEqual(ALWAYS_VISIBLE_PROVIDER_IDS);
+      });
+    });
+  });
+
+  it("still runs the replacing session's connect request after the replaced session closes late, and cancels the replaced session's remaining tasks", async () => {
+    await withTestHarness(async (harness) => {
+      installCatalogStore(harness, { clock: { now: BASE_NOW } });
+      const logLines = captureLogLines(harness);
+      const hold = createHold();
+      const first = registerResponder(harness, {
+        ...seedDaemonHost(harness, "host-prewarm-replacement"),
+        listModels: (_command, hostId) => hold.answer(hostId),
+      });
+
+      await withPrewarm(harness, async () => {
+        await vi.waitFor(() => {
+          expect(hold.outstanding).toHaveLength(2);
+        });
+        const second = registerResponder(harness, {
+          hostId: first.hostId,
+          sessionId: seedSession(harness.deps, first.hostId).id,
+        });
+        handleDaemonSocketClosed(harness.deps, { sessionId: first.sessionId });
+        harness.hub.notifyHost(first.hostId, ["host-disconnected"]);
+        expect(harness.hub.getDaemonSessionIdForHost(first.hostId)).toBe(
+          second.sessionId,
+        );
+        await waitForPasses(logLines, 2);
+
+        expect(first.listRequests()).toHaveLength(2);
+        expect(second.listedProviderIds()).toEqual(ALWAYS_VISIBLE_PROVIDER_IDS);
+      });
+    });
+  });
+
+  it("warms only active persistent hosts, including a resumed host with a leftover operation id and a created host once it is active", async () => {
+    await withTestHarness(async (harness) => {
+      installCatalogStore(harness, { clock: { now: BASE_NOW } });
+      const logLines = captureLogLines(harness);
+
+      const seed = (
+        hostId: string,
+        patch: Parameters<typeof updateHost>[3],
+      ) => {
+        const host = seedDaemonHost(harness, hostId);
+        updateHost(harness.db, harness.hub, host.hostId, patch);
+        return host;
+      };
+      const hosts = [
+        seed("host-prewarm-suspended", {
+          phase: "suspended",
+          suspendedAt: BASE_NOW,
+        }),
+        seed("host-prewarm-resuming", {
+          phase: "resuming",
+          machineOperationId: "op-resuming",
+        }),
+        seed("host-prewarm-ephemeral", { type: "ephemeral" }),
+        seed("host-prewarm-destroyed", { destroyedAt: BASE_NOW }),
+        seed("host-prewarm-creating", {
+          phase: "creating",
+          machineOperationId: "op-creating",
+        }),
+        seed("host-prewarm-resumed", {
+          phase: "active",
+          machineOperationId: "op-resumed",
+        }),
+      ];
+
+      await withPrewarm(harness, async () => {
+        const responders = hosts.map((host) =>
+          registerResponder(harness, host),
+        );
+        const resumed = responders.pop()!;
+        const creating = responders.at(-1)!;
+        await waitForPasses(logLines, 1);
+        await settleTimers();
+
+        for (const responder of responders) {
+          expect(responder.commands).toEqual([]);
+        }
+        expect(resumed.listedProviderIds()).toEqual(
+          ALWAYS_VISIBLE_PROVIDER_IDS,
+        );
+        expect(logLines(PASS_FINISHED).map(({ hostId }) => hostId)).toEqual([
+          resumed.hostId,
+        ]);
+
+        updateHost(harness.db, harness.hub, creating.hostId, {
+          phase: "active",
+          machineOperationId: null,
+        });
+        harness.hub.notifyHost(creating.hostId, ["host-connected"]);
+        await waitForPasses(logLines, 2);
+        expect(creating.listedProviderIds()).toEqual(
+          ALWAYS_VISIBLE_PROVIDER_IDS,
+        );
+      });
+    });
+  });
+
+  it("sends nothing until provider registrations settle", async () => {
+    await withTestHarness(async (harness) => {
+      installCatalogStore(harness, { clock: { now: BASE_NOW } });
+      const logLines = captureLogLines(harness);
+      const registry = createProviderRegistryService({
+        deferRegistrationsSettled: true,
+      });
+      await registerFirstPartyProviders(registry, {
+        artifacts: harness.deps.pluginHostArtifacts,
+      });
+      harness.deps.providerRegistry = registry;
+      const host = seedDaemonHost(harness, "host-prewarm-settle");
+
+      await withPrewarm(harness, async () => {
+        const responder = registerResponder(harness, host);
+        await settleTimers(50);
+        expect(responder.commands).toEqual([]);
+
+        registry.markRegistrationsSettled();
+        await waitForPasses(logLines, 1);
+        expect(responder.listedProviderIds()).toEqual(
+          ALWAYS_VISIBLE_PROVIDER_IDS,
+        );
+      });
+    });
+  });
+
+  it("coalesces host-connected notifications during a running pass into one follow-up pass that refreshes nothing fresh", async () => {
+    await withTestHarness(async (harness) => {
+      installCatalogStore(harness, { clock: { now: BASE_NOW } });
+      const logLines = captureLogLines(harness);
+      const hold = createHold();
+      const responder = registerResponder(harness, {
+        ...seedDaemonHost(harness, "host-prewarm-coalesce"),
+        listModels: (_command, hostId) => hold.answer(hostId),
+      });
+
+      await withPrewarm(harness, async () => {
+        await vi.waitFor(() => {
+          expect(hold.outstanding).toHaveLength(2);
+        });
+        harness.hub.notifyHost(responder.hostId, ["host-connected"]);
+        harness.hub.notifyHost(responder.hostId, ["host-connected"]);
+        await releaseHeldOneByOne(hold, ALWAYS_VISIBLE_PROVIDER_IDS.length);
+        await waitForPasses(logLines, 2);
+        await settleTimers();
+
+        expect(logLines(PASS_FINISHED)).toHaveLength(2);
+        expect(responder.listRequests()).toHaveLength(
+          ALWAYS_VISIBLE_PROVIDER_IDS.length,
+        );
+      });
+    });
+  });
+
+  it("sends nothing after stop and drops the remaining tasks", async () => {
+    await withTestHarness(async (harness) => {
+      installCatalogStore(harness, { clock: { now: BASE_NOW } });
+      const hold = createHold();
+      const responder = registerResponder(harness, {
+        ...seedDaemonHost(harness, "host-prewarm-stop"),
+        listModels: (_command, hostId) => hold.answer(hostId),
+      });
+      const prewarm = installProviderModelCatalogPrewarm(harness.deps);
+      await vi.waitFor(() => {
+        expect(hold.outstanding).toHaveLength(2);
+      });
+      const commandCount = responder.commands.length;
+
+      prewarm.stop();
+      for (const held of [...hold.outstanding]) {
+        held.release();
+      }
+      harness.hub.notifyHost(responder.hostId, ["host-connected"]);
+      harness.hub.notifySystem(["provider-registrations-changed"]);
+      await settleTimers(50);
+
+      expect(responder.commands).toHaveLength(commandCount);
+      expect(responder.listRequests()).toHaveLength(2);
+    });
+  });
+});

--- a/apps/server/test/providers/provider-model-catalog-store.test.ts
+++ b/apps/server/test/providers/provider-model-catalog-store.test.ts
@@ -1,0 +1,835 @@
+import {
+  getAppSettings,
+  getStoredProviderModelCatalog,
+  setAppSettings,
+  updateHost,
+} from "@bb/db";
+import type { JsonValue, ProviderFork } from "@bb/domain";
+import type { HostDaemonOnlineRpcRequestMessage } from "@bb/host-daemon-contract";
+import { createDeferredPromise } from "@bb/test-helpers";
+import { describe, expect, it, vi } from "vitest";
+import {
+  resolveSystemExecutionOptions,
+  resolveSystemProviderModels,
+} from "../../src/services/system/execution-options.js";
+import { resolveBridgeLaunchForProviderId } from "../../src/services/system/provider-bridge-launch.js";
+import { applyThreadExecutionOverride } from "../../src/services/threads/thread-execution-override.js";
+import {
+  registerHostRpcResponder,
+  type HostRpcHandlerResult,
+} from "../helpers/host-rpc.js";
+import {
+  captureLogLines,
+  capturePushes,
+  catalogAnswer,
+  errorAnswer,
+  healthAnswer,
+  installCatalogStore,
+  modelList,
+  requireRegistration,
+  settleTimers,
+} from "../helpers/provider-model-catalogs.js";
+import {
+  seedEnvironment,
+  seedHostSession,
+  seedProjectWithSource,
+  seedSession,
+  seedThread,
+} from "../helpers/seed.js";
+import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
+
+const BASE_NOW = 1_800_000_000_000;
+const SECOND = 1_000;
+const MINUTE = 60 * SECOND;
+const SETTLED = "Provider model catalog refresh settled";
+
+type ListModelsCommand = Extract<
+  HostDaemonOnlineRpcRequestMessage["command"],
+  { type: "provider.list_models" }
+>;
+
+type ListModelsAnswer = (
+  command: ListModelsCommand,
+) => HostRpcHandlerResult | Promise<HostRpcHandlerResult>;
+
+function setupCatalogHost(
+  harness: TestAppHarness,
+  args: { id: string; memoryEntryLimit?: number },
+) {
+  const clock = { now: BASE_NOW };
+  const store = installCatalogStore(harness, {
+    clock,
+    memoryEntryLimit: args.memoryEntryLimit,
+  });
+  const { host, session } = seedHostSession(harness.deps, { id: args.id });
+  let answer: ListModelsAnswer = (command) =>
+    catalogAnswer(modelList(`${command.providerId}-model`));
+  const connect = (sessionId: string) => {
+    const responder = registerHostRpcResponder(harness, {
+      hostId: host.id,
+      sessionId,
+      handle: (request) => {
+        switch (request.command.type) {
+          case "provider.health":
+            return healthAnswer("not_installed");
+          case "provider.list_models":
+            return answer(request.command);
+          case "provider.installation.run":
+            return {
+              ok: true,
+              result: {
+                events: [
+                  {
+                    type: "completed",
+                    provider: request.command.providerId,
+                    exitCode: 0,
+                    signal: null,
+                    success: true,
+                  },
+                ],
+              },
+            };
+          default:
+            throw new Error(`Unexpected RPC command ${request.command.type}`);
+        }
+      },
+    });
+    return (providerId?: string): ListModelsCommand[] =>
+      responder.requests.flatMap((request) =>
+        request.command.type === "provider.list_models" &&
+        (providerId === undefined || request.command.providerId === providerId)
+          ? [request.command]
+          : [],
+      );
+  };
+  return {
+    clock,
+    store,
+    hostId: host.id,
+    sessionId: session.id,
+    connect,
+    listRequests: connect(session.id),
+    setAnswer(next: ListModelsAnswer) {
+      answer = next;
+    },
+    read(providerId: string, environmentId?: string) {
+      return resolveSystemExecutionOptions(
+        harness.deps,
+        environmentId === undefined
+          ? { hostId: host.id, providerId }
+          : { environmentId, providerId },
+      );
+    },
+  };
+}
+
+function modelIds(response: { models: readonly { model: string }[] }) {
+  return response.models.map((model) => model.model);
+}
+
+function fallbackModelIds(harness: TestAppHarness, providerId: string) {
+  const ids = requireRegistration(harness, providerId).fallbackModels.map(
+    (model) => model.model,
+  );
+  expect(ids.length).toBeGreaterThan(0);
+  return ids;
+}
+
+function registerCatalogProbe(
+  harness: TestAppHarness,
+  args: {
+    bridgeOptions?: Readonly<Record<string, JsonValue>>;
+    fork?: ProviderFork;
+  },
+) {
+  const base = requireRegistration(harness, "claude-code");
+  return harness.deps.providerRegistry.register({
+    ...base,
+    info: { ...base.info, id: "catalog-probe" },
+    bridgeOptions: args.bridgeOptions ?? base.bridgeOptions,
+    serverCapabilities: {
+      ...base.serverCapabilities,
+      fork: args.fork ?? base.serverCapabilities.fork,
+    },
+  });
+}
+
+function seedEnvironmentPath(
+  harness: TestAppHarness,
+  hostId: string,
+  path: string,
+): string {
+  const { project } = seedProjectWithSource(harness.deps, { hostId, path });
+  return seedEnvironment(harness.deps, { hostId, projectId: project.id, path })
+    .id;
+}
+
+describe("provider model catalog store", () => {
+  it("keeps catalogs across a daemon reconnect, an unrelated registration and a capability-only re-registration", async () => {
+    await withTestHarness(async (harness) => {
+      const host = setupCatalogHost(harness, { id: "host-catalog-identity" });
+      const probe = registerCatalogProbe(harness, {});
+      const fork = resolveBridgeLaunchForProviderId(
+        harness.deps,
+        "catalog-probe",
+      )?.capabilities.fork;
+      await host.read("codex");
+      await host.read("catalog-probe");
+
+      harness.hub.unregisterDaemon(host.sessionId);
+      const nextRequests = host.connect(
+        seedSession(harness.deps, host.hostId).id,
+      );
+      const codex = requireRegistration(harness, "codex");
+      harness.deps.providerRegistry.register({
+        ...codex,
+        pluginId: "unrelated-plugin",
+        info: { ...codex.info, id: "unrelated-provider" },
+      });
+      probe.dispose();
+      registerCatalogProbe(harness, { fork: fork === "none" ? "tip" : "none" });
+      expect(
+        resolveBridgeLaunchForProviderId(harness.deps, "catalog-probe")
+          ?.capabilities.fork,
+      ).not.toBe(fork);
+
+      expect(modelIds(await host.read("codex"))).toEqual(["codex-model"]);
+      expect(modelIds(await host.read("catalog-probe"))).toEqual([
+        "catalog-probe-model",
+      ]);
+      expect(nextRequests()).toHaveLength(0);
+    });
+  });
+
+  it("treats a fingerprint change as a missing catalog and never serves the old models", async () => {
+    await withTestHarness(async (harness) => {
+      const host = setupCatalogHost(harness, {
+        id: "host-catalog-fingerprint",
+      });
+      await host.read("claude-code");
+      const artifact = harness.deps.pluginHostArtifacts.get(
+        "provider-claude-code",
+      );
+      if (artifact === undefined) {
+        throw new Error("Missing claude-code artifact");
+      }
+      harness.deps.pluginHostArtifacts.set("provider-claude-code", {
+        ...artifact,
+        digest: "b".repeat(64),
+      });
+      host.setAnswer(() => errorAnswer("command_failed"));
+
+      const response = await host.read("claude-code");
+      expect(response.modelLoadError).toEqual({
+        providerId: "claude-code",
+        code: "failed",
+      });
+      expect(modelIds(response)).toEqual(
+        fallbackModelIds(harness, "claude-code"),
+      );
+      expect(host.listRequests()).toHaveLength(2);
+    });
+  });
+
+  it("serves a stale catalog at once with one background refresh and pushes only when the list changes", async () => {
+    await withTestHarness(async (harness) => {
+      const logLines = captureLogLines(harness);
+      const host = setupCatalogHost(harness, { id: "host-catalog-stale" });
+      await host.read("claude-code");
+      await settleTimers();
+      const pushes = capturePushes(harness);
+      const held = createDeferredPromise<HostRpcHandlerResult>();
+
+      host.clock.now += 10 * MINUTE;
+      host.setAnswer(() => held.promise);
+      const [first, second] = await Promise.all([
+        host.read("claude-code"),
+        host.read("claude-code"),
+      ]);
+      expect(modelIds(first)).toEqual(["claude-code-model"]);
+      expect(modelIds(second)).toEqual(["claude-code-model"]);
+      expect(host.listRequests()).toHaveLength(2);
+      held.resolve(catalogAnswer(modelList("claude-next")));
+      await vi.waitFor(async () => {
+        expect(modelIds(await host.read("claude-code"))).toEqual([
+          "claude-next",
+        ]);
+      });
+      await settleTimers();
+      expect(pushes).toEqual([host.hostId]);
+
+      host.clock.now += 10 * MINUTE;
+      host.setAnswer(() => catalogAnswer(modelList("claude-next")));
+      await host.read("claude-code");
+      await vi.waitFor(() => {
+        expect(host.listRequests()).toHaveLength(3);
+      });
+      await settleTimers();
+      expect(pushes).toEqual([host.hostId]);
+      expect(
+        logLines(SETTLED).map(({ level, outcome, changed }) => [
+          level,
+          outcome,
+          changed,
+        ]),
+      ).toEqual([
+        ["info", "success", true],
+        ["info", "success", true],
+        ["info", "success", false],
+      ]);
+      expect(logLines(SETTLED)[0]).toMatchObject({
+        hostId: host.hostId,
+        providerId: "claude-code",
+        scope: "host",
+        modelCount: 1,
+        durationMs: expect.any(Number),
+      });
+    });
+  });
+
+  it.each([
+    {
+      label: "fails",
+      answer: errorAnswer("command_failed"),
+      level: "warn",
+      outcome: "failed",
+    },
+    {
+      label: "times out",
+      answer: errorAnswer("command_timeout"),
+      level: "warn",
+      outcome: "timeout",
+    },
+    {
+      label: "answers for another command type",
+      answer: null,
+      level: "error",
+      outcome: "failed",
+    },
+  ])(
+    "keeps serving the last good catalog when a refresh $label, without a push or a row rewrite",
+    async ({ answer, level, outcome }) => {
+      await withTestHarness(async (harness) => {
+        const logLines = captureLogLines(harness);
+        const host = setupCatalogHost(harness, {
+          id: "host-catalog-last-good",
+        });
+        await host.read("claude-code");
+        await settleTimers();
+        const pushes = capturePushes(harness);
+        const rowKey = {
+          hostId: host.hostId,
+          providerId: "claude-code",
+          scopeKey: "",
+        };
+        const row = getStoredProviderModelCatalog(harness.db, rowKey);
+        if (answer === null) {
+          const request = harness.hub.requestHostOnlineRpc.bind(harness.hub);
+          vi.spyOn(harness.hub, "requestHostOnlineRpc").mockImplementation(
+            async (args) =>
+              args.message.command.type === "provider.list_models"
+                ? {
+                    type: "host-rpc.response",
+                    requestId: args.message.requestId,
+                    commandType: "provider.installation.run",
+                    ok: true,
+                    result: { events: [] },
+                  }
+                : request(args),
+          );
+        } else {
+          host.setAnswer(() => answer);
+        }
+
+        host.clock.now += 10 * MINUTE;
+        await host.read("claude-code");
+        await vi.waitFor(() => {
+          expect(logLines(SETTLED)).toHaveLength(2);
+        });
+        await settleTimers();
+        const response = await host.read("claude-code");
+        expect(response.modelLoadError).toBeNull();
+        expect(modelIds(response)).toEqual(["claude-code-model"]);
+        expect(getStoredProviderModelCatalog(harness.db, rowKey)).toEqual(row);
+        await settleTimers();
+        expect(pushes).toEqual([]);
+        expect(logLines(SETTLED)).toHaveLength(2);
+        expect(logLines(SETTLED)[1]).toMatchObject({
+          level,
+          outcome,
+          changed: false,
+        });
+      });
+    },
+  );
+
+  it("answers recorded failures without waiting for 30 seconds, then waits once for auth_required and refreshes a timeout in the background", async () => {
+    await withTestHarness(async (harness) => {
+      const host = setupCatalogHost(harness, {
+        id: "host-catalog-negative-cache",
+      });
+      const held = createDeferredPromise<HostRpcHandlerResult>();
+      let codexAnswer = () => errorAnswer("auth_required");
+      let claudeAnswer = ():
+        | HostRpcHandlerResult
+        | Promise<HostRpcHandlerResult> => errorAnswer("command_timeout");
+      host.setAnswer((command) =>
+        command.providerId === "codex" ? codexAnswer() : claudeAnswer(),
+      );
+      const readError = async (providerId: string) =>
+        (await host.read(providerId)).modelLoadError?.code;
+
+      expect(await readError("codex")).toBe("auth_required");
+      expect(await readError("claude-code")).toBe("timeout");
+      host.clock.now += 29 * SECOND;
+      expect(await readError("codex")).toBe("auth_required");
+      expect(await readError("claude-code")).toBe("timeout");
+      expect(host.listRequests()).toHaveLength(2);
+
+      host.clock.now += SECOND;
+      codexAnswer = () => catalogAnswer(modelList("gpt-ready"));
+      claudeAnswer = () => held.promise;
+      expect(await readError("claude-code")).toBe("timeout");
+      await vi.waitFor(() => {
+        expect(host.listRequests("claude-code")).toHaveLength(2);
+      });
+      expect(modelIds(await host.read("codex"))).toEqual(["gpt-ready"]);
+      expect(host.listRequests("codex")).toHaveLength(2);
+      held.resolve(errorAnswer("command_timeout"));
+
+      host.clock.now += 10 * MINUTE;
+      codexAnswer = () => errorAnswer("auth_required");
+      expect(modelIds(await host.read("codex"))).toEqual(["gpt-ready"]);
+      await vi.waitFor(() => {
+        expect(host.listRequests("codex")).toHaveLength(3);
+      });
+      await settleTimers();
+      const surfaced = await host.read("codex");
+      expect(surfaced.modelLoadError).toEqual({
+        providerId: "codex",
+        code: "auth_required",
+      });
+      expect(surfaced.models).toEqual([]);
+    });
+  });
+
+  it("waits through recorded failures for validation and refreshes a catalog at least a minute old that lacks the override's model", async () => {
+    await withTestHarness(async (harness) => {
+      const host = setupCatalogHost(harness, { id: "host-catalog-validation" });
+      let codexAnswer = () => catalogAnswer(modelList("gpt-5"));
+      host.setAnswer((command) =>
+        command.providerId === "codex"
+          ? codexAnswer()
+          : errorAnswer("command_failed"),
+      );
+      await host.read("claude-code");
+      await host.read("claude-code");
+      expect(host.listRequests("claude-code")).toHaveLength(1);
+      const validated = await resolveSystemProviderModels(harness.deps, {
+        hostId: host.hostId,
+        providerId: "claude-code",
+      });
+      expect(validated.modelLoadError?.code).toBe("failed");
+      expect(host.listRequests("claude-code")).toHaveLength(2);
+
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.hostId,
+        path: "/tmp/catalog-override",
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.hostId,
+        projectId: project.id,
+        path: "/tmp/catalog-override",
+      });
+      const thread = seedThread(harness.deps, {
+        environmentId: environment.id,
+        projectId: project.id,
+        providerId: "codex",
+        status: "idle",
+      });
+      const override = (model: string) =>
+        applyThreadExecutionOverride(harness.deps, {
+          thread,
+          patch: { model },
+        });
+      const invalidModel = { status: 400, body: { code: "invalid_request" } };
+      await host.read("codex", environment.id);
+
+      host.clock.now += 61 * SECOND;
+      codexAnswer = () => catalogAnswer(modelList("gpt-5", "gpt-new"));
+      await override("gpt-new");
+      expect(host.listRequests("codex")).toHaveLength(2);
+
+      host.clock.now += 30 * SECOND;
+      codexAnswer = () => catalogAnswer(modelList("gpt-5", "gpt-newer"));
+      await expect(override("gpt-newer")).rejects.toMatchObject(invalidModel);
+      expect(host.listRequests("codex")).toHaveLength(2);
+
+      host.clock.now += 31 * SECOND;
+      await expect(override("gpt-unknown")).rejects.toMatchObject(invalidModel);
+      expect(host.listRequests("codex")).toHaveLength(3);
+
+      host.clock.now += 61 * SECOND;
+      codexAnswer = () => errorAnswer("command_timeout");
+      await expect(override("gpt-other")).rejects.toMatchObject(invalidModel);
+      expect(host.listRequests("codex")).toHaveLength(4);
+    });
+  });
+
+  it("serves a persisted catalog to a new store and treats a corrupt row as missing", async () => {
+    await withTestHarness(async (harness) => {
+      const host = setupCatalogHost(harness, {
+        id: "host-catalog-persistence",
+      });
+      await host.read("codex");
+
+      installCatalogStore(harness, { clock: host.clock });
+      expect(modelIds(await host.read("codex"))).toEqual(["codex-model"]);
+      expect(host.listRequests()).toHaveLength(1);
+
+      harness.db.$client
+        .prepare(
+          "UPDATE provider_model_catalogs SET models_json = ? WHERE host_id = ?",
+        )
+        .run("{not json", host.hostId);
+      installCatalogStore(harness, { clock: host.clock });
+      expect(modelIds(await host.read("codex"))).toEqual(["codex-model"]);
+      expect(host.listRequests()).toHaveLength(2);
+    });
+  });
+
+  it("persists one row per workspace path for workspace-scoped providers and one host row otherwise", async () => {
+    await withTestHarness(async (harness) => {
+      const host = setupCatalogHost(harness, { id: "host-catalog-workspace" });
+      const [environmentA, environmentB] = [
+        "/tmp/catalog-pi-a",
+        "/tmp/catalog-pi-b",
+      ].map((path) => seedEnvironmentPath(harness, host.hostId, path));
+      await host.read("pi", environmentA);
+      await host.read("pi", environmentB);
+      await host.read("pi", environmentA);
+      await host.read("claude-code", environmentA);
+
+      const rowExists = (providerId: string, scopeKey: string) =>
+        getStoredProviderModelCatalog(harness.db, {
+          hostId: host.hostId,
+          providerId,
+          scopeKey,
+        }) !== null;
+      expect([
+        rowExists("pi", "/tmp/catalog-pi-a"),
+        rowExists("pi", "/tmp/catalog-pi-b"),
+        rowExists("pi", ""),
+        rowExists("claude-code", ""),
+      ]).toEqual([true, true, false, true]);
+      expect(host.listRequests().map((command) => command.cwd)).toEqual([
+        "/tmp/catalog-pi-a",
+        "/tmp/catalog-pi-b",
+        undefined,
+      ]);
+    });
+  });
+
+  it("records no failure and sends no push when a refresh fails after its daemon session changed or because the host is not active", async () => {
+    await withTestHarness(async (harness) => {
+      const logLines = captureLogLines(harness);
+      const host = setupCatalogHost(harness, {
+        id: "host-catalog-host-unavailable",
+      });
+      const pushes = capturePushes(harness);
+      const lateFailure = createDeferredPromise<void>();
+      const request = harness.hub.requestHostOnlineRpc.bind(harness.hub);
+      let holdNextList = true;
+      vi.spyOn(harness.hub, "requestHostOnlineRpc").mockImplementation(
+        async (args) => {
+          if (
+            args.message.command.type !== "provider.list_models" ||
+            !holdNextList
+          ) {
+            return request(args);
+          }
+          holdNextList = false;
+          await lateFailure.promise;
+          return {
+            type: "host-rpc.response",
+            requestId: args.message.requestId,
+            commandType: "provider.list_models",
+            ok: false,
+            errorCode: "command_failed",
+            errorMessage: "Runtime shutting down",
+          };
+        },
+      );
+
+      const pending = host.read("claude-code");
+      await vi.waitFor(() => {
+        expect(holdNextList).toBe(false);
+      });
+      const nextRequests = host.connect(
+        seedSession(harness.deps, host.hostId).id,
+      );
+      lateFailure.resolve();
+      const failed = await pending;
+      expect(failed.modelLoadError?.code).toBe("failed");
+      expect(modelIds(failed)).toEqual(
+        fallbackModelIds(harness, "claude-code"),
+      );
+
+      updateHost(harness.db, harness.hub, host.hostId, { phase: "creating" });
+      expect((await host.read("claude-code")).modelLoadError?.code).toBe(
+        "failed",
+      );
+      updateHost(harness.db, harness.hub, host.hostId, { phase: "active" });
+      expect(modelIds(await host.read("claude-code"))).toEqual([
+        "claude-code-model",
+      ]);
+      expect(nextRequests()).toHaveLength(1);
+      await settleTimers();
+      expect(pushes).toEqual([host.hostId]);
+      expect(
+        logLines(SETTLED).map(({ outcome, errorCode }) => [outcome, errorCode]),
+      ).toEqual([
+        ["host_unavailable", "command_failed"],
+        ["host_unavailable", "host_unavailable"],
+        ["success", undefined],
+      ]);
+    });
+  });
+
+  it("ignores a refresh that settles after a later refresh under another fingerprint", async () => {
+    await withTestHarness(async (harness) => {
+      const host = setupCatalogHost(harness, { id: "host-catalog-superseded" });
+      const base = requireRegistration(harness, "claude-code");
+      const heldOne = createDeferredPromise<HostRpcHandlerResult>();
+      const heldTwo = createDeferredPromise<HostRpcHandlerResult>();
+      host.setAnswer((command) =>
+        command.bridgeLaunch.providerOptions.catalogProbe === "one"
+          ? heldOne.promise
+          : heldTwo.promise,
+      );
+      const firstProbe = registerCatalogProbe(harness, {
+        bridgeOptions: { ...base.bridgeOptions, catalogProbe: "one" },
+      });
+      const first = host.read("catalog-probe");
+      await vi.waitFor(() => {
+        expect(host.listRequests()).toHaveLength(1);
+      });
+      firstProbe.dispose();
+      registerCatalogProbe(harness, {
+        bridgeOptions: { ...base.bridgeOptions, catalogProbe: "two" },
+      });
+      const second = host.read("catalog-probe");
+      await vi.waitFor(() => {
+        expect(host.listRequests()).toHaveLength(2);
+      });
+
+      heldTwo.resolve(catalogAnswer(modelList("model-two")));
+      expect(modelIds(await second)).toEqual(["model-two"]);
+      heldOne.resolve(catalogAnswer(modelList("model-one")));
+      await first;
+
+      expect(modelIds(await host.read("catalog-probe"))).toEqual(["model-two"]);
+      expect(host.listRequests()).toHaveLength(2);
+      expect(
+        getStoredProviderModelCatalog(harness.db, {
+          hostId: host.hostId,
+          providerId: "catalog-probe",
+          scopeKey: "",
+        })?.modelsJson,
+      ).toContain("model-two");
+    });
+  });
+
+  it("clears a provider's recorded failure in every workspace scope after a successful install", async () => {
+    await withTestHarness(async (harness) => {
+      const host = setupCatalogHost(harness, { id: "host-catalog-install" });
+      const environmentId = seedEnvironmentPath(
+        harness,
+        host.hostId,
+        "/tmp/catalog-install",
+      );
+      host.setAnswer(() => errorAnswer("missing_executable"));
+      await host.read("pi", environmentId);
+      await host.read("pi", environmentId);
+      expect(host.listRequests("pi")).toHaveLength(1);
+
+      const install = await harness.app.request(
+        `/api/v1/hosts/${host.hostId}/provider-clis/install`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ provider: "pi", actionKind: "install" }),
+        },
+      );
+      expect(install.status).toBe(200);
+      expect(await install.text()).toContain('"success":true');
+      host.setAnswer(() => catalogAnswer(modelList("pi-installed")));
+
+      expect(modelIds(await host.read("pi", environmentId))).toEqual([
+        "pi-installed",
+      ]);
+      expect(host.listRequests("pi")).toHaveLength(2);
+    });
+  });
+
+  it("marks catalogs stale and drops failures when the machine environment is saved, including a refresh that was in flight", async () => {
+    await withTestHarness(async (harness) => {
+      const host = setupCatalogHost(harness, {
+        id: "host-catalog-machine-environment",
+      });
+      setAppSettings(harness.db, {
+        ...getAppSettings(harness.db),
+        machineGitCredentialsEnabled: false,
+      });
+      const held = createDeferredPromise<HostRpcHandlerResult>();
+      let saved = false;
+      host.setAnswer((command) => {
+        if (saved) {
+          return catalogAnswer(modelList(`${command.providerId}-after`));
+        }
+        switch (command.providerId) {
+          case "claude-code":
+            return errorAnswer("auth_required");
+          case "pi":
+            return held.promise;
+          default:
+            return catalogAnswer(modelList(`${command.providerId}-before`));
+        }
+      });
+      await host.read("codex");
+      await host.read("claude-code");
+      const coldPi = host.read("pi");
+      await vi.waitFor(() => {
+        expect(host.listRequests("pi")).toHaveLength(1);
+      });
+
+      const response = await harness.app.request(
+        "/api/v1/settings/machine-environment",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            variables: [{ name: "CATALOG_REGION", value: "two", note: null }],
+          }),
+        },
+      );
+      expect(response.status).toBe(200);
+      held.resolve(catalogAnswer(modelList("pi-before")));
+      expect(modelIds(await coldPi)).toEqual(["pi-before"]);
+      saved = true;
+
+      expect(modelIds(await host.read("claude-code"))).toEqual([
+        "claude-code-after",
+      ]);
+      for (const providerId of ["codex", "pi"]) {
+        expect(modelIds(await host.read(providerId))).toEqual([
+          `${providerId}-before`,
+        ]);
+        await vi.waitFor(async () => {
+          expect(modelIds(await host.read(providerId))).toEqual([
+            `${providerId}-after`,
+          ]);
+        });
+        expect(host.listRequests(providerId)).toHaveLength(2);
+      }
+    });
+  });
+
+  it("never evicts an entry with an in-flight refresh and reloads evicted entries from SQLite", async () => {
+    await withTestHarness(async (harness) => {
+      const host = setupCatalogHost(harness, {
+        id: "host-catalog-eviction",
+        memoryEntryLimit: 2,
+      });
+      const held = createDeferredPromise<HostRpcHandlerResult>();
+      host.setAnswer((command) =>
+        command.providerId === "claude-code"
+          ? held.promise
+          : catalogAnswer(modelList(`${command.providerId}-model`)),
+      );
+      const heldRead = host.read("claude-code");
+      await vi.waitFor(() => {
+        expect(host.listRequests("claude-code")).toHaveLength(1);
+      });
+      await host.read("codex");
+      await host.read("acp-cursor");
+      const joinedRead = host.read("claude-code");
+      await settleTimers();
+      expect(host.listRequests("claude-code")).toHaveLength(1);
+      held.resolve(catalogAnswer(modelList("claude-held")));
+      expect(modelIds(await heldRead)).toEqual(["claude-held"]);
+      expect(modelIds(await joinedRead)).toEqual(["claude-held"]);
+
+      harness.db.$client
+        .prepare(
+          "UPDATE provider_model_catalogs SET models_json = ? WHERE host_id = ? AND provider_id = 'codex'",
+        )
+        .run(JSON.stringify(modelList("codex-from-sqlite")), host.hostId);
+      expect(modelIds(await host.read("codex"))).toEqual(["codex-from-sqlite"]);
+      expect(host.listRequests("codex")).toHaveLength(1);
+    });
+  });
+
+  it("forgets a removed host's catalogs, persists and pushes nothing for its in-flight refreshes, and never persists ephemeral hosts", async () => {
+    await withTestHarness(async (harness) => {
+      const host = setupCatalogHost(harness, { id: "host-catalog-forget" });
+      const environmentId = seedEnvironmentPath(
+        harness,
+        host.hostId,
+        "/tmp/catalog-forget",
+      );
+      await host.read("pi", environmentId);
+      await host.read("claude-code");
+      const held = createDeferredPromise<HostRpcHandlerResult>();
+      host.setAnswer(() => held.promise);
+      const pending = host.read("codex");
+      await vi.waitFor(() => {
+        expect(host.listRequests("codex")).toHaveLength(1);
+      });
+      const pushes = capturePushes(harness);
+      const rowCount = () =>
+        harness.db.$client
+          .prepare(
+            "SELECT COUNT(*) AS count FROM provider_model_catalogs WHERE host_id = ?",
+          )
+          .get(host.hostId);
+
+      host.store.forgetHost(harness.deps, host.hostId);
+      expect(rowCount()).toEqual({ count: 0 });
+      held.resolve(catalogAnswer(modelList("late-model")));
+      expect((await pending).modelLoadError?.code).toBe("failed");
+      await settleTimers();
+      expect(pushes).toEqual([]);
+      expect(rowCount()).toEqual({ count: 0 });
+      await host.read("claude-code");
+      expect(host.listRequests("claude-code")).toHaveLength(2);
+
+      const ephemeral = seedHostSession(harness.deps, {
+        id: "host-catalog-ephemeral",
+      });
+      updateHost(harness.db, harness.hub, ephemeral.host.id, {
+        type: "ephemeral",
+      });
+      registerHostRpcResponder(harness, {
+        hostId: ephemeral.host.id,
+        sessionId: ephemeral.session.id,
+        handle: (request) =>
+          request.command.type === "provider.list_models"
+            ? catalogAnswer(modelList("gpt-5"))
+            : healthAnswer("not_installed"),
+      });
+      const response = await resolveSystemExecutionOptions(harness.deps, {
+        hostId: ephemeral.host.id,
+        providerId: "codex",
+      });
+      expect(modelIds(response)).toEqual(["gpt-5"]);
+      expect(
+        getStoredProviderModelCatalog(harness.db, {
+          hostId: ephemeral.host.id,
+          providerId: "codex",
+          scopeKey: "",
+        }),
+      ).toBeNull();
+    });
+  });
+});

--- a/apps/server/test/providers/provider-registry.test.ts
+++ b/apps/server/test/providers/provider-registry.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { createDeferredPromise } from "@bb/test-helpers";
+import { describe, expect, it, vi } from "vitest";
 import { createProviderRegistryService } from "../../src/services/providers/provider-registry.js";
 import { minimalProviderRegistration } from "../helpers/provider-registry.js";
 
@@ -351,7 +352,7 @@ describe("installed-state cache", () => {
     expect(probes).toBe(1);
   });
 
-  it("drops the answer when the registration revision moves", async () => {
+  it("serves the answer when the registration revision moves and replaces it after exactly one revalidation", async () => {
     const registry = createProviderRegistryService({});
     registerProvider(registry, "codex", "provider-codex");
     const key = {
@@ -359,11 +360,53 @@ describe("installed-state cache", () => {
       providerId: "codex",
     };
     registry.rememberInstalled(key, Promise.resolve(true));
-    expect(await registry.lookupInstalled(key)).toBe(true);
+    const held = createDeferredPromise<boolean>();
+    const probe = vi.fn(() => held.promise);
+    await registry.revalidateInstalled(key, probe);
+    expect(probe).not.toHaveBeenCalled();
 
     registerProvider(registry, "claude-code", "provider-claude-code");
 
-    expect(registry.lookupInstalled(key)).toBeUndefined();
+    expect(await registry.lookupInstalled(key)).toBe(true);
+    const revalidation = registry.revalidateInstalled(key, probe);
+    void registry.revalidateInstalled(key, probe);
+    expect(probe).toHaveBeenCalledTimes(1);
+    held.resolve(false);
+    await revalidation;
+    expect(await registry.lookupInstalled(key)).toBe(false);
+    await registry.revalidateInstalled(key, probe);
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops an expired answer when its revalidation fails and never writes a revalidation over a newer answer", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(1_800_000_000_000);
+      const registry = createProviderRegistryService({});
+      const failing = { hostId: "host_1", providerId: "codex" };
+      const replaced = { hostId: "host_1", providerId: "pi" };
+      registry.rememberInstalled(failing, Promise.resolve(true));
+      registry.rememberInstalled(replaced, Promise.resolve(true));
+      vi.setSystemTime(1_800_000_000_000 + 5 * 60_000);
+
+      await registry.revalidateInstalled(failing, () =>
+        Promise.reject(new Error("health failed")),
+      );
+      expect(registry.lookupInstalled(failing)).toBeUndefined();
+
+      const held = createDeferredPromise<boolean>();
+      const revalidation = registry.revalidateInstalled(
+        replaced,
+        () => held.promise,
+      );
+      registry.forgetAllInstalled();
+      registry.rememberInstalled(replaced, Promise.resolve(true));
+      held.resolve(false);
+      await revalidation;
+      expect(await registry.lookupInstalled(replaced)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("forgets one host-provider answer or all answers", async () => {

--- a/apps/server/test/public/public-host-management.test.ts
+++ b/apps/server/test/public/public-host-management.test.ts
@@ -2,7 +2,9 @@ import {
   getEnvironment,
   getHost,
   getSessionById,
+  getStoredProviderModelCatalog,
   getThread,
+  replaceStoredProviderModelCatalog,
   updateHost,
 } from "@bb/db";
 import {
@@ -465,6 +467,32 @@ describe("public host management", () => {
         { method: "DELETE" },
       );
       expect(secondDelete.status).toBe(404);
+    });
+  });
+
+  it("deletes a removed host's stored provider model catalogs", async () => {
+    await withTestHarness(async (harness) => {
+      const primary = seedHost(harness.deps, { id: "host_primary" });
+      seedPrimaryHost(harness.deps, primary.id);
+      const host = seedHost(harness.deps, { id: "host_remove_catalogs" });
+      const key = { hostId: host.id, providerId: "codex", scopeKey: "" };
+      replaceStoredProviderModelCatalog(harness.db, {
+        row: {
+          ...key,
+          fingerprint: "fingerprint",
+          modelsJson: "[]",
+          selectedOnlyModelsJson: "[]",
+          fetchedAt: 1,
+        },
+        pruneWorkspaceRowsFetchedBefore: null,
+      });
+
+      const response = await harness.app.request(`${API}/hosts/${host.id}`, {
+        method: "DELETE",
+      });
+
+      expect(response.status).toBe(200);
+      expect(getStoredProviderModelCatalog(harness.db, key)).toBeNull();
     });
   });
 

--- a/apps/server/test/services/machines/provider-orchestration.test.ts
+++ b/apps/server/test/services/machines/provider-orchestration.test.ts
@@ -5,8 +5,10 @@ import {
   environments,
   getHost,
   getEnvironment,
+  getStoredProviderModelCatalog,
   hosts,
   archiveThread,
+  replaceStoredProviderModelCatalog,
   setThreadStartupContext,
   updateHost,
 } from "@bb/db";
@@ -507,6 +509,34 @@ describe("machine retirement", () => {
       }
       expect(getHost(harness.db, host.id)?.phase).toBe("destroyed");
       expect(remove).toHaveBeenCalledOnce();
+    }));
+
+  it("deletes the removed machine's stored provider model catalogs", async () =>
+    withTestHarness(async (harness) => {
+      installMachineProvider();
+      const { host } = seedHostSession(harness.deps);
+      updateHost(harness.db, harness.hub, host.id, {
+        machineProviderId: "test-machine",
+        resource: { allocation: "cancelled" },
+        phase: "active",
+      });
+      const key = { hostId: host.id, providerId: "codex", scopeKey: "" };
+      replaceStoredProviderModelCatalog(harness.db, {
+        row: {
+          ...key,
+          fingerprint: "fingerprint",
+          modelsJson: "[]",
+          selectedOnlyModelsJson: "[]",
+          fetchedAt: 1,
+        },
+        pruneWorkspaceRowsFetchedBefore: null,
+      });
+
+      expect(requestMachineRemoval(harness.deps, host.id)).toBe(true);
+      await sweepProviderMachine(harness.deps, host.id);
+
+      expect(getHost(harness.db, host.id)?.phase).toBe("destroyed");
+      expect(getStoredProviderModelCatalog(harness.db, key)).toBeNull();
     }));
 
   it("retries failed teardown at removeRetryAt", async () =>

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { getAppSettings, setAppSettings, updateHost } from "@bb/db";
+import { createDeferredPromise } from "@bb/test-helpers";
 import {
   hostDaemonServerWsMessageSchema,
   type HostDaemonOnlineRpcRequestMessage,
@@ -23,7 +24,6 @@ import {
   seedHost,
   seedHostSession,
   seedProjectWithSource,
-  seedSession,
 } from "../helpers/seed.js";
 import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
 import {
@@ -1176,10 +1176,11 @@ describe("resolveSystemExecutionOptions", () => {
       });
 
       const providerModelWarning = warn.mock.calls.find(
-        ([, message]) => message === "Failed to resolve provider models",
+        ([, message]) => message === "Provider model catalog refresh settled",
       );
       expect(providerModelWarning).toBeDefined();
       expect(providerModelWarning?.[0]).toMatchObject({
+        outcome: "failed",
         errorCode: "command_failed",
         errorMessage: "model list failed",
         errorRetryable: false,
@@ -1518,7 +1519,7 @@ function seedEnvironmentPath(
   }).id;
 }
 
-describe("resolveSystemExecutionOptions model probe memo", () => {
+describe("resolveSystemExecutionOptions provider model catalog", () => {
   it("serves a host-scoped catalog to every environment on the host from one probe without the workspace path", async () => {
     await withTestHarness({}, async (harness) => {
       const { host, session } = seedHostSession(harness.deps, {
@@ -1645,85 +1646,59 @@ describe("resolveSystemExecutionOptions model probe memo", () => {
     });
   });
 
-  it("does not memoize a failed probe and re-probes after the daemon reconnects", async () => {
+  it("serves expired installed-only answers without waiting and revalidates each provider once in the background", async () => {
     await withTestHarness({}, async (harness) => {
-      const { host, session } = seedHostSession(harness.deps, {
-        id: "host-model-memo-invalidation",
-      });
-      const catalogModel = availableModelFixture({ model: "gpt-5" });
-      let failProbe = true;
-      const responder = registerHostRpcResponder(harness, {
-        hostId: host.id,
-        sessionId: session.id,
-        handle: (request) => {
-          if (request.command.type === "provider.health") {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      try {
+        vi.setSystemTime(1_800_000_000_000);
+        const { host, session } = seedHostSession(harness.deps, {
+          id: "host-installed-only-serve-stale",
+        });
+        const heldHealth = createDeferredPromise<void>();
+        let expired = false;
+        const responder = registerHostRpcResponder(harness, {
+          hostId: host.id,
+          sessionId: session.id,
+          handle: async (request) => {
+            if (request.command.type !== "provider.health") {
+              throw new Error(`Unexpected RPC command ${request.command.type}`);
+            }
+            const opencode = request.command.providerId === "acp-opencode";
+            if (expired && opencode) {
+              await heldHealth.promise;
+            }
             return {
               ok: true,
-              result: providerDiscoveryHealth(false),
+              result: providerDiscoveryHealth(!expired && opencode),
             };
-          }
-          if (request.command.type !== "provider.list_models") {
-            throw new Error(`Unexpected RPC command ${request.command.type}`);
-          }
-          if (failProbe) {
-            return {
-              ok: false,
-              errorCode: "command_timeout",
-              errorMessage: "Model probe timed out",
-            };
-          }
-          return {
-            ok: true,
-            result: { models: [catalogModel], selectedOnlyModels: [] },
-          };
-        },
-      });
-      const query = { hostId: host.id, providerId: "codex" };
-
-      const failed = await resolveSystemExecutionOptions(harness.deps, query);
-      expect(failed.modelLoadError).toEqual({
-        providerId: "codex",
-        code: "timeout",
-      });
-
-      failProbe = false;
-      const recovered = await resolveSystemExecutionOptions(
-        harness.deps,
-        query,
-      );
-      expect(recovered.modelLoadError).toBeNull();
-      expect(recovered.models).toEqual([catalogModel]);
-      await resolveSystemExecutionOptions(harness.deps, query);
-      expect(
-        responder.requests.filter(
-          (request) => request.command.type === "provider.list_models",
-        ),
-      ).toHaveLength(2);
-
-      harness.hub.unregisterDaemon(session.id);
-      const nextSession = seedSession(harness.deps, host.id);
-      const nextResponder = registerProviderHostRpcResponder(harness, {
-        hostId: host.id,
-        sessionId: nextSession.id,
-        modelsByProviderId: {
-          codex: {
-            models: [availableModelFixture({ model: "gpt-6" })],
-            selectedOnlyModels: [],
           },
-        },
-      });
-      const afterReconnect = await resolveSystemExecutionOptions(
-        harness.deps,
-        query,
-      );
-      expect(afterReconnect.models.map((model) => model.model)).toEqual([
-        "gpt-6",
-      ]);
-      expect(
-        nextResponder.requests.filter(
-          (request) => request.command.type === "provider.list_models",
-        ),
-      ).toHaveLength(1);
+        });
+        const healthCount = () => responder.requests.length;
+        const listIds = async () =>
+          (
+            await listSystemProviderInfos(harness.deps, { hostId: host.id })
+          ).map((provider) => provider.id);
+        expect(await listIds()).toContain("acp-opencode");
+        const probeCount = healthCount();
+        expect(probeCount).toBeGreaterThan(1);
+
+        vi.setSystemTime(1_800_000_000_000 + 5 * 60_000);
+        expired = true;
+        expect(await listIds()).toContain("acp-opencode");
+        await vi.waitFor(() => {
+          expect(healthCount()).toBe(2 * probeCount);
+        });
+        expect(await listIds()).toContain("acp-opencode");
+        expect(healthCount()).toBe(2 * probeCount);
+
+        heldHealth.resolve();
+        await vi.waitFor(async () => {
+          expect(await listIds()).not.toContain("acp-opencode");
+        });
+        expect(healthCount()).toBe(2 * probeCount);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -1043,7 +1043,9 @@ answers when its provider is a user-installed CLI. The probes:
 `experimental_resolveExecutablePath` (the command's absolute path — the path
 itself when given absolute and executable, else the first `which`/`where`
 hit, null when absent; 5 s), `experimental_readCliVersion` (`<command>
---version`, the first `x.y.z[-pre]` on stdout or stderr; 5 s),
+--version` with stdin closed, so CLIs that start a stdio server on unknown
+flags exit instead of hitting the timeout; the first `x.y.z[-pre]` on stdout
+or stderr; 5 s),
 `experimental_commandOutput` (any command's trimmed stdout+stderr or null on
 failure; 15 s), `experimental_versionFrom` (the first version token in a
 banner), `experimental_npmLatestVersion` (`npm view <package> version`) and
@@ -1838,6 +1840,10 @@ target one enrolled host or an existing environment;
 omitting it uses primary-machine routing. `disabled` renders the same summary
 without opening the picker. Verified catalogs also normalize an empty or stale
 controlled selection; placeholder, failed, and empty catalogs do not.
+Verified data may come from the machine's stored catalog while a background
+refresh runs, or while that provider's refresh keeps failing or timing out, so
+a model newer than the stored list can be normalized away before a refresh
+lands.
 `allowProviderChange={false}` hides provider tabs while retaining model,
 reasoning, and service-tier selection for the controlled provider. Routing
 never implies provider locking: an environment supplies host/workspace context

--- a/docs/provider-plugin-api.md
+++ b/docs/provider-plugin-api.md
@@ -86,6 +86,13 @@ bb.providers.register({
 // => { dispose(): void }
 ```
 
+bb keeps each machine's last successful `model/list` answer per
+`models.scope` across daemon reconnects and server restarts, serves it
+immediately, and refreshes it in the background once it is 10 minutes old. A
+stored answer is discarded when the bridge fingerprint changes (plugin bundle
+digest, bridge options, env passthrough). A list that depends on login state,
+CLI version, or environment values is corrected only by the next refresh.
+
 Still experimental on the declaration (see api_to_audit.md):
 `experimental_visibility` (`"installed"` hides the row until the bridge's
 health probe finds the agent), `experimental_bridgeOptions` (immutable JSON

--- a/packages/db/drizzle/0119_provider_model_catalogs.sql
+++ b/packages/db/drizzle/0119_provider_model_catalogs.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `provider_model_catalogs` (
+	`host_id` text NOT NULL,
+	`provider_id` text NOT NULL,
+	`scope_key` text NOT NULL,
+	`fingerprint` text NOT NULL,
+	`models_json` text NOT NULL,
+	`selected_only_models_json` text NOT NULL,
+	`fetched_at` integer NOT NULL,
+	PRIMARY KEY(`host_id`, `provider_id`, `scope_key`),
+	FOREIGN KEY (`host_id`) REFERENCES `hosts`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/packages/db/drizzle/meta/0119_snapshot.json
+++ b/packages/db/drizzle/meta/0119_snapshot.json
@@ -1,0 +1,4391 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "233bbedf-e452-4229-8b05-7b4a158ce833",
+  "prevId": "9f028f13-e871-4131-bb39-5f242ffa3f92",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caffeinate": {
+          "name": "caffeinate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "show_keyboard_hints": {
+          "name": "show_keyboard_hints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "steer_active_thread_on_enter": {
+          "name": "steer_active_thread_on_enter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "show_unhandled_provider_events": {
+          "name": "show_unhandled_provider_events",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "codex_memory_enabled": {
+          "name": "codex_memory_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "claude_code_memory_enabled": {
+          "name": "claude_code_memory_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "codex_subagents_disabled": {
+          "name": "codex_subagents_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claude_code_subagents_disabled": {
+          "name": "claude_code_subagents_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claude_code_workflows_disabled": {
+          "name": "claude_code_workflows_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "keybinding_overrides": {
+          "name": "keybinding_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_settings_values": {
+      "name": "app_settings_values",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_theme": {
+      "name": "app_theme",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "favicon_color": {
+          "name": "favicon_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refillInterval": {
+          "name": "refillInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refillAmount": {
+          "name": "refillAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastRefillAt": {
+          "name": "lastRefillAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitEnabled": {
+          "name": "rateLimitEnabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitTimeWindow": {
+          "name": "rateLimitTimeWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitMax": {
+          "name": "rateLimitMax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requestCount": {
+          "name": "requestCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastRequest": {
+          "name": "lastRequest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configId": {
+          "name": "configId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_key_unique": {
+          "name": "apikey_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            "referenceId"
+          ],
+          "isUnique": false
+        },
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            "configId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_referenceId_user_id_fk": {
+          "name": "apikey_referenceId_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "referenceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environment_hook_operations": {
+      "name": "environment_hook_operations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_worktree": {
+          "name": "is_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "merge_base_branch": {
+          "name": "merge_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_provider_id": {
+          "name": "environment_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_provider_plugin_id": {
+          "name": "environment_provider_plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_owns_path": {
+          "name": "provider_owns_path",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "environment_provider_selection": {
+          "name": "environment_provider_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_provider_instance_key": {
+          "name": "environment_provider_instance_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retire_at": {
+          "name": "retire_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "teardown_attempt": {
+          "name": "teardown_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "teardown_status": {
+          "name": "teardown_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "teardown_message": {
+          "name": "teardown_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_thread_id": {
+          "name": "owner_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_log": {
+          "name": "pending_log",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "claim_path": {
+          "name": "claim_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provisioning'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "environments_project_host_path_idx": {
+          "name": "environments_project_host_path_idx",
+          "columns": [
+            "project_id",
+            "host_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "environments_host_path_lookup_idx": {
+          "name": "environments_host_path_lookup_idx",
+          "columns": [
+            "host_id",
+            "path"
+          ],
+          "isUnique": false
+        },
+        "environments_owner_thread_idx": {
+          "name": "environments_owner_thread_idx",
+          "columns": [
+            "owner_thread_id"
+          ],
+          "isUnique": true
+        },
+        "environments_claim_idx": {
+          "name": "environments_claim_idx",
+          "columns": [
+            "host_id",
+            "claim_path"
+          ],
+          "isUnique": false
+        },
+        "environments_project_idx": {
+          "name": "environments_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "environments_status_idx": {
+          "name": "environments_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "environments_provider_instance_idx": {
+          "name": "environments_provider_instance_idx",
+          "columns": [
+            "environment_provider_id",
+            "environment_provider_instance_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "environments_project_id_projects_id_fk": {
+          "name": "environments_project_id_projects_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environments_host_id_hosts_id_fk": {
+          "name": "environments_host_id_hosts_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_tool_call_id": {
+          "name": "parent_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_thread_sequence_idx": {
+          "name": "events_thread_sequence_idx",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "events_delegating_item_lookup_idx": {
+          "name": "events_delegating_item_lookup_idx",
+          "columns": [
+            "thread_id",
+            "item_id",
+            "sequence",
+            "item_kind"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"item_kind\" IN ('toolCall', 'delegation')"
+        },
+        "events_plan_steps_thread_sequence_idx": {
+          "name": "events_plan_steps_thread_sequence_idx",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "(\"events\".\"item_kind\" = 'planSteps' AND \"events\".\"type\" = 'item/completed') OR \"events\".\"type\" = 'turn/plan/updated'"
+        },
+        "events_parent_tool_call_thread_parent_sequence_idx": {
+          "name": "events_parent_tool_call_thread_parent_sequence_idx",
+          "columns": [
+            "thread_id",
+            "parent_tool_call_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"parent_tool_call_id\" IS NOT NULL"
+        },
+        "events_thread_type_item_kind_sequence_idx": {
+          "name": "events_thread_type_item_kind_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "item_kind",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_background_task_thread_type_item_sequence_idx": {
+          "name": "events_background_task_thread_type_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"item_kind\" = 'backgroundTask'"
+        },
+        "events_thread_type_sequence_idx": {
+          "name": "events_thread_type_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_thread_turn_type_item_sequence_idx": {
+          "name": "events_thread_turn_type_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "turn_id",
+            "type",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_item_lifecycle_thread_item_sequence_idx": {
+          "name": "events_item_lifecycle_thread_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" IN ('item/started', 'item/completed', 'item/backgroundTask/completed')"
+        },
+        "events_environment_idx": {
+          "name": "events_environment_idx",
+          "columns": [
+            "environment_id"
+          ],
+          "isUnique": false
+        },
+        "events_completed_item_truncation_idx": {
+          "name": "events_completed_item_truncation_idx",
+          "columns": [
+            "item_kind",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" = 'item/completed'"
+        },
+        "events_thread_state_thread_sequence_idx": {
+          "name": "events_thread_state_thread_sequence_idx",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" IN ('thread/goal/updated', 'thread/goal/cleared', 'thread/extensionState/updated')"
+        }
+      },
+      "foreignKeys": {
+        "events_thread_id_threads_id_fk": {
+          "name": "events_thread_id_threads_id_fk",
+          "tableFrom": "events",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_environment_id_environments_id_fk": {
+          "name": "events_environment_id_environments_id_fk",
+          "tableFrom": "events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "events_scope_shape_check": {
+          "name": "events_scope_shape_check",
+          "value": "(\n        (\"events\".\"scope_kind\" = 'turn' AND \"events\".\"turn_id\" IS NOT NULL)\n        OR\n        (\"events\".\"scope_kind\" = 'thread' AND \"events\".\"turn_id\" IS NULL)\n      )"
+        }
+      }
+    },
+    "host_daemon_sessions": {
+      "name": "host_daemon_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_name": {
+          "name": "host_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_dir": {
+          "name": "data_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_interval_ms": {
+          "name": "heartbeat_interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_timeout_ms": {
+          "name": "lease_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_daemon_sessions_host_status_idx": {
+          "name": "host_daemon_sessions_host_status_idx",
+          "columns": [
+            "host_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "host_daemon_sessions_host_latest_idx": {
+          "name": "host_daemon_sessions_host_latest_idx",
+          "columns": [
+            "host_id",
+            "updated_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "host_daemon_sessions_closed_prune_idx": {
+          "name": "host_daemon_sessions_closed_prune_idx",
+          "columns": [
+            "status",
+            "closed_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "host_daemon_sessions_host_id_hosts_id_fk": {
+          "name": "host_daemon_sessions_host_id_hosts_id_fk",
+          "tableFrom": "host_daemon_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hosts": {
+      "name": "hosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connect_machine_id": {
+          "name": "connect_machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "machine_provider_id": {
+          "name": "machine_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "launch_key": {
+          "name": "launch_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "machine_inputs": {
+          "name": "machine_inputs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "machine_attempt": {
+          "name": "machine_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pending_log": {
+          "name": "pending_log",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "machine_operation_id": {
+          "name": "machine_operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_access_provider_id": {
+          "name": "server_access_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_access_grant_id": {
+          "name": "server_access_grant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suspend_retry_at": {
+          "name": "suspend_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remove_retry_at": {
+          "name": "remove_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "teardown_attempt": {
+          "name": "teardown_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "teardown_status": {
+          "name": "teardown_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_permission_mode": {
+          "name": "max_permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'full'"
+        },
+        "destroyed_at": {
+          "name": "destroyed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_rejected_protocol_version": {
+          "name": "last_rejected_protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hosts_last_seen_idx": {
+          "name": "hosts_last_seen_idx",
+          "columns": [
+            "last_seen_at"
+          ],
+          "isUnique": false
+        },
+        "hosts_live_launch_key_idx": {
+          "name": "hosts_live_launch_key_idx",
+          "columns": [
+            "launch_key"
+          ],
+          "isUnique": true,
+          "where": "\"hosts\".\"destroyed_at\" is null"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugins": {
+      "name": "plugins",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "catalog_entry_id": {
+          "name": "catalog_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "catalog_marketplace_name": {
+          "name": "catalog_marketplace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'path'"
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_builtin_name": {
+          "name": "source_builtin_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_package": {
+          "name": "source_npm_package",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_registry": {
+          "name": "source_npm_registry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_requested_spec": {
+          "name": "source_npm_requested_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_spec_kind": {
+          "name": "source_npm_spec_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_url": {
+          "name": "source_git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_subdirectory": {
+          "name": "source_git_subdirectory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_requested_ref": {
+          "name": "source_git_requested_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_ref_kind": {
+          "name": "source_git_ref_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_range": {
+          "name": "source_git_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_tag_prefix": {
+          "name": "source_git_tag_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_resolved_tag": {
+          "name": "source_git_resolved_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "npm_resolved_version": {
+          "name": "npm_resolved_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "npm_integrity": {
+          "name": "npm_integrity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_resolved_commit": {
+          "name": "git_resolved_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_update_check_at": {
+          "name": "last_update_check_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available_compatible_version": {
+          "name": "available_compatible_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "newest_incompatible_version": {
+          "name": "newest_incompatible_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "update_status_detail": {
+          "name": "update_status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_failure_version": {
+          "name": "last_failure_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_failure_at": {
+          "name": "last_failure_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_failure_detail": {
+          "name": "last_failure_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_artifact_id": {
+          "name": "active_artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "normalization_version": {
+          "name": "normalization_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "root_dir": {
+          "name": "root_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plugins_active_artifact_id_plugin_artifacts_id_fk": {
+          "name": "plugins_active_artifact_id_plugin_artifacts_id_fk",
+          "tableFrom": "plugins",
+          "tableTo": "plugin_artifacts",
+          "columnsFrom": [
+            "active_artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_scan_cursors": {
+      "name": "maintenance_scan_cursors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_path": {
+          "name": "output_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_created_at": {
+          "name": "last_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "maintenance_scan_cursors_path_idx": {
+          "name": "maintenance_scan_cursors_path_idx",
+          "columns": [
+            "policy",
+            "version",
+            "item_kind",
+            "output_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pending_interactions": {
+      "name": "pending_interactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provider'"
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_request_id": {
+          "name": "provider_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "renderer_id": {
+          "name": "renderer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pending_interactions_provider_request_idx": {
+          "name": "pending_interactions_provider_request_idx",
+          "columns": [
+            "provider_id",
+            "provider_thread_id",
+            "provider_request_id"
+          ],
+          "isUnique": true
+        },
+        "pending_interactions_thread_created_idx": {
+          "name": "pending_interactions_thread_created_idx",
+          "columns": [
+            "thread_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_thread_status_created_idx": {
+          "name": "pending_interactions_thread_status_created_idx",
+          "columns": [
+            "thread_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_status_created_idx": {
+          "name": "pending_interactions_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_plugin_status_created_idx": {
+          "name": "pending_interactions_plugin_status_created_idx",
+          "columns": [
+            "plugin_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pending_interactions_thread_id_threads_id_fk": {
+          "name": "pending_interactions_thread_id_threads_id_fk",
+          "tableFrom": "pending_interactions",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_artifacts": {
+      "name": "plugin_artifacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "npm_resolved_version": {
+          "name": "npm_resolved_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_resolved_commit": {
+          "name": "git_resolved_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_checkout_root": {
+          "name": "git_checkout_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_result": {
+          "name": "validation_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_artifacts_plugin_idx": {
+          "name": "plugin_artifacts_plugin_idx",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_kv": {
+      "name": "plugin_kv",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_kv_plugin_id_key_pk": {
+          "columns": [
+            "plugin_id",
+            "key"
+          ],
+          "name": "plugin_kv_plugin_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_marketplace_icons": {
+      "name": "plugin_marketplace_icons",
+      "columns": {
+        "marketplace_name": {
+          "name": "marketplace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_marketplace_icons_marketplace_name_entry_id_pk": {
+          "columns": [
+            "marketplace_name",
+            "entry_id"
+          ],
+          "name": "plugin_marketplace_icons_marketplace_name_entry_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_marketplaces": {
+      "name": "plugin_marketplaces",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'https'"
+        },
+        "manifest_url": {
+          "name": "manifest_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_git_ref": {
+          "name": "source_git_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_commit": {
+          "name": "source_git_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manifest_json": {
+          "name": "manifest_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stats_json": {
+          "name": "stats_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_successful_refresh_at": {
+          "name": "last_successful_refresh_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_attempted_refresh_at": {
+          "name": "last_attempted_refresh_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_schedules": {
+      "name": "plugin_schedules",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_schedules_plugin_id_name_pk": {
+          "columns": [
+            "plugin_id",
+            "name"
+          ],
+          "name": "plugin_schedules_plugin_id_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_settings": {
+      "name": "plugin_settings",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_settings_plugin_id_key_pk": {
+          "columns": [
+            "plugin_id",
+            "key"
+          ],
+          "name": "plugin_settings_plugin_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_state_snapshots": {
+      "name": "plugin_state_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_artifact_id": {
+          "name": "from_artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_artifact_id": {
+          "name": "to_artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_path": {
+          "name": "snapshot_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "database_path": {
+          "name": "database_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_path": {
+          "name": "state_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secrets_path": {
+          "name": "secrets_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registration_path": {
+          "name": "registration_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rollback_candidate_version": {
+          "name": "rollback_candidate_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_source_fingerprint": {
+          "name": "rollback_source_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_bb_version": {
+          "name": "rollback_bb_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_sdk_version": {
+          "name": "rollback_sdk_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_detail": {
+          "name": "rollback_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retained_until": {
+          "name": "retained_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_state_snapshots_plugin_idx": {
+          "name": "plugin_state_snapshots_plugin_idx",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_state_snapshots_retention_idx": {
+          "name": "plugin_state_snapshots_retention_idx",
+          "columns": [
+            "retained_until"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_execution_defaults": {
+      "name": "project_execution_defaults",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_execution_defaults_project_idx": {
+          "name": "project_execution_defaults_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_execution_defaults_project_id_projects_id_fk": {
+          "name": "project_execution_defaults_project_id_projects_id_fk",
+          "tableFrom": "project_execution_defaults",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_sources": {
+      "name": "project_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owns_path": {
+          "name": "owns_path",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_sources_project_idx": {
+          "name": "project_sources_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "project_sources_host_idx": {
+          "name": "project_sources_host_idx",
+          "columns": [
+            "host_id"
+          ],
+          "isUnique": false
+        },
+        "project_sources_project_host_idx": {
+          "name": "project_sources_project_host_idx",
+          "columns": [
+            "project_id",
+            "host_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_sources_project_id_projects_id_fk": {
+          "name": "project_sources_project_id_projects_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_sources_host_id_hosts_id_fk": {
+          "name": "project_sources_host_id_hosts_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "project_sources_shape_check": {
+          "name": "project_sources_shape_check",
+          "value": "(\n        \"project_sources\".\"type\" = 'local_path' AND \"project_sources\".\"host_id\" IS NOT NULL AND \"project_sources\".\"path\" IS NOT NULL\n      )"
+        }
+      }
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'standard'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_remote_url": {
+          "name": "git_remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'V'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_updated_idx": {
+          "name": "projects_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "projects_deleted_idx": {
+          "name": "projects_deleted_idx",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "projects_sort_idx": {
+          "name": "projects_sort_idx",
+          "columns": [
+            "sort_key",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "projects_personal_singleton_idx": {
+          "name": "projects_personal_singleton_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"kind\" = 'personal'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_history_entries": {
+      "name": "prompt_history_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_sequence": {
+          "name": "request_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompt_history_entries_thread_request_idx": {
+          "name": "prompt_history_entries_thread_request_idx",
+          "columns": [
+            "thread_id",
+            "request_sequence"
+          ],
+          "isUnique": true
+        },
+        "prompt_history_entries_project_scope_created_idx": {
+          "name": "prompt_history_entries_project_scope_created_idx",
+          "columns": [
+            "project_id",
+            "scope",
+            "created_at",
+            "request_sequence",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "prompt_history_entries_thread_scope_created_idx": {
+          "name": "prompt_history_entries_thread_scope_created_idx",
+          "columns": [
+            "thread_id",
+            "scope",
+            "created_at",
+            "request_sequence",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "prompt_history_entries_project_id_projects_id_fk": {
+          "name": "prompt_history_entries_project_id_projects_id_fk",
+          "tableFrom": "prompt_history_entries",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prompt_history_entries_thread_id_threads_id_fk": {
+          "name": "prompt_history_entries_thread_id_threads_id_fk",
+          "tableFrom": "prompt_history_entries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_model_catalogs": {
+      "name": "provider_model_catalogs",
+      "columns": {
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "models_json": {
+          "name": "models_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selected_only_models_json": {
+          "name": "selected_only_models_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_model_catalogs_host_id_hosts_id_fk": {
+          "name": "provider_model_catalogs_host_id_hosts_id_fk",
+          "tableFrom": "provider_model_catalogs",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "provider_model_catalogs_host_id_provider_id_scope_key_pk": {
+          "columns": [
+            "host_id",
+            "provider_id",
+            "scope_key"
+          ],
+          "name": "provider_model_catalogs_host_id_provider_id_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_thread_messages": {
+      "name": "queued_thread_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_notice": {
+          "name": "system_notice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_thread_id": {
+          "name": "sender_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_with_next": {
+          "name": "group_with_next",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "send_at": {
+          "name": "send_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "waiting_on": {
+          "name": "waiting_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wait_holder": {
+          "name": "wait_holder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_kind": {
+          "name": "payload_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inline'"
+        },
+        "retry_of_turn_request_id": {
+          "name": "retry_of_turn_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_attempt": {
+          "name": "retry_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_reason": {
+          "name": "retry_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "queued_thread_messages_thread_created_idx": {
+          "name": "queued_thread_messages_thread_created_idx",
+          "columns": [
+            "thread_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "queued_thread_messages_thread_sort_idx": {
+          "name": "queued_thread_messages_thread_sort_idx",
+          "columns": [
+            "thread_id",
+            "sort_key",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "queued_thread_messages_due_idx": {
+          "name": "queued_thread_messages_due_idx",
+          "columns": [
+            "send_at",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"queued_thread_messages\".\"send_at\" IS NOT NULL AND \"queued_thread_messages\".\"claimed_at\" IS NULL AND \"queued_thread_messages\".\"claim_token\" IS NULL"
+        },
+        "queued_thread_messages_wait_holder_idx": {
+          "name": "queued_thread_messages_wait_holder_idx",
+          "columns": [
+            "wait_holder",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"queued_thread_messages\".\"wait_holder\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "queued_thread_messages_thread_id_threads_id_fk": {
+          "name": "queued_thread_messages_thread_id_threads_id_fk",
+          "tableFrom": "queued_thread_messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "retained_event_outputs": {
+      "name": "retained_event_outputs",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_path": {
+          "name": "output_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "retained_event_outputs_expiry_idx": {
+          "name": "retained_event_outputs_expiry_idx",
+          "columns": [
+            "expires_at",
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "retained_event_outputs_event_id_events_id_fk": {
+          "name": "retained_event_outputs_event_id_events_id_fk",
+          "tableFrom": "retained_event_outputs",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_experiments": {
+      "name": "system_experiments",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daemon_session_id": {
+          "name": "daemon_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_cwd": {
+          "name": "initial_cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cols": {
+          "name": "cols",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rows": {
+          "name": "rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_user_input_at": {
+          "name": "last_user_input_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_thread_status_updated_idx": {
+          "name": "terminal_sessions_thread_status_updated_idx",
+          "columns": [
+            "thread_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_environment_status_idx": {
+          "name": "terminal_sessions_environment_status_idx",
+          "columns": [
+            "environment_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_host_status_idx": {
+          "name": "terminal_sessions_host_status_idx",
+          "columns": [
+            "host_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_daemon_session_idx": {
+          "name": "terminal_sessions_daemon_session_idx",
+          "columns": [
+            "daemon_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_thread_id_threads_id_fk": {
+          "name": "terminal_sessions_thread_id_threads_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_environment_id_environments_id_fk": {
+          "name": "terminal_sessions_environment_id_environments_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_host_id_hosts_id_fk": {
+          "name": "terminal_sessions_host_id_hosts_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_daemon_session_id_host_daemon_sessions_id_fk": {
+          "name": "terminal_sessions_daemon_session_id_host_daemon_sessions_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "host_daemon_sessions",
+          "columnsFrom": [
+            "daemon_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_conversation_outlines": {
+      "name": "thread_conversation_outlines",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projection_key": {
+          "name": "projection_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "items_json": {
+          "name": "items_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_conversation_outlines_thread_id_threads_id_fk": {
+          "name": "thread_conversation_outlines_thread_id_threads_id_fk",
+          "tableFrom": "thread_conversation_outlines",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_dynamic_context_file_states": {
+      "name": "thread_dynamic_context_file_states",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_status": {
+          "name": "content_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_dynamic_context_file_states_thread_file_idx": {
+          "name": "thread_dynamic_context_file_states_thread_file_idx",
+          "columns": [
+            "thread_id",
+            "file_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thread_dynamic_context_file_states_thread_id_threads_id_fk": {
+          "name": "thread_dynamic_context_file_states_thread_id_threads_id_fk",
+          "tableFrom": "thread_dynamic_context_file_states",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_plugin_metadata": {
+      "name": "thread_plugin_metadata",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_plugin_metadata_thread_id_threads_id_fk": {
+          "name": "thread_plugin_metadata_thread_id_threads_id_fk",
+          "tableFrom": "thread_plugin_metadata",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "thread_plugin_metadata_thread_id_plugin_id_pk": {
+          "columns": [
+            "thread_id",
+            "plugin_id"
+          ],
+          "name": "thread_plugin_metadata_thread_id_plugin_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_search_segments": {
+      "name": "thread_search_segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_seq": {
+          "name": "source_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_search_segments_source_idx": {
+          "name": "thread_search_segments_source_idx",
+          "columns": [
+            "thread_id",
+            "source_kind",
+            "source_key"
+          ],
+          "isUnique": true
+        },
+        "thread_search_segments_thread_source_seq_idx": {
+          "name": "thread_search_segments_thread_source_seq_idx",
+          "columns": [
+            "thread_id",
+            "source_seq"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thread_search_segments_thread_id_threads_id_fk": {
+          "name": "thread_search_segments_thread_id_threads_id_fk",
+          "tableFrom": "thread_search_segments",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_sections": {
+      "name": "thread_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_sections_name_idx": {
+          "name": "thread_sections_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_tabs": {
+      "name": "thread_tabs",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tabs_json": {
+          "name": "tabs_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_tabs_thread_id_threads_id_fk": {
+          "name": "thread_tabs_thread_id_threads_id_fk",
+          "tableFrom": "thread_tabs",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_override": {
+          "name": "model_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_level_override": {
+          "name": "reasoning_level_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title_fallback": {
+          "name": "title_fallback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'starting'"
+        },
+        "startup_context": {
+          "name": "startup_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_plugin_id": {
+          "name": "origin_plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'visible'"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pin_sort_key": {
+          "name": "pin_sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_attention_at": {
+          "name": "latest_attention_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "threads_project_updated_idx": {
+          "name": "threads_project_updated_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "threads_project_archived_deleted_idx": {
+          "name": "threads_project_archived_deleted_idx",
+          "columns": [
+            "project_id",
+            "archived_at",
+            "deleted_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "threads_pin_sort_idx": {
+          "name": "threads_pin_sort_idx",
+          "columns": [
+            "archived_at",
+            "deleted_at",
+            "pin_sort_key",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"threads\".\"pinned_at\" IS NOT NULL"
+        },
+        "threads_environment_idx": {
+          "name": "threads_environment_idx",
+          "columns": [
+            "environment_id"
+          ],
+          "isUnique": false
+        },
+        "threads_parent_idx": {
+          "name": "threads_parent_idx",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "threads_source_origin_idx": {
+          "name": "threads_source_origin_idx",
+          "columns": [
+            "source_thread_id",
+            "origin_kind"
+          ],
+          "isUnique": false
+        },
+        "threads_origin_plugin_archived_idx": {
+          "name": "threads_origin_plugin_archived_idx",
+          "columns": [
+            "origin_plugin_id",
+            "archived_at"
+          ],
+          "isUnique": false
+        },
+        "threads_section_archived_deleted_idx": {
+          "name": "threads_section_archived_deleted_idx",
+          "columns": [
+            "section_id",
+            "archived_at",
+            "deleted_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "threads_archived_status_idx": {
+          "name": "threads_archived_status_idx",
+          "columns": [
+            "archived_at",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "threads_environment_archived_deleted_idx": {
+          "name": "threads_environment_archived_deleted_idx",
+          "columns": [
+            "environment_id",
+            "archived_at",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "threads_active_maintenance_idx": {
+          "name": "threads_active_maintenance_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false,
+          "where": "\"threads\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "threads_project_id_projects_id_fk": {
+          "name": "threads_project_id_projects_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_environment_id_environments_id_fk": {
+          "name": "threads_environment_id_environments_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_section_id_thread_sections_id_fk": {
+          "name": "threads_section_id_thread_sections_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "thread_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_parent_thread_id_threads_id_fk": {
+          "name": "threads_parent_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "parent_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_source_thread_id_threads_id_fk": {
+          "name": "threads_source_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "source_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ui_preferences": {
+      "name": "ui_preferences",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -834,6 +834,13 @@
       "when": 1789175706080,
       "tag": "0118_brave_marvel_zombies",
       "breakpoints": true
+    },
+    {
+      "idx": 119,
+      "version": "6",
+      "when": 1789226927698,
+      "tag": "0119_provider_model_catalogs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -247,6 +247,16 @@ export {
 } from "./hosts.js";
 
 export {
+  deleteStoredProviderModelCatalogsForHost,
+  getStoredProviderModelCatalog,
+  replaceStoredProviderModelCatalog,
+} from "./provider-model-catalogs.js";
+export type {
+  ProviderModelCatalogRowKey,
+  StoredProviderModelCatalog,
+} from "./provider-model-catalogs.js";
+
+export {
   appendDaemonEventsInTransaction,
   appendStoredThreadEvent,
   copyStoredThreadEventsInTransaction,

--- a/packages/db/src/data/provider-model-catalogs.ts
+++ b/packages/db/src/data/provider-model-catalogs.ts
@@ -1,0 +1,82 @@
+import { and, eq, lt, ne } from "drizzle-orm";
+import type { DbConnection } from "../connection.js";
+import { providerModelCatalogs } from "../schema.js";
+
+export type StoredProviderModelCatalog =
+  typeof providerModelCatalogs.$inferSelect;
+
+export type ProviderModelCatalogRowKey = Pick<
+  StoredProviderModelCatalog,
+  "hostId" | "providerId" | "scopeKey"
+>;
+
+export function getStoredProviderModelCatalog(
+  db: DbConnection,
+  key: ProviderModelCatalogRowKey,
+): StoredProviderModelCatalog | null {
+  return (
+    db
+      .select()
+      .from(providerModelCatalogs)
+      .where(
+        and(
+          eq(providerModelCatalogs.hostId, key.hostId),
+          eq(providerModelCatalogs.providerId, key.providerId),
+          eq(providerModelCatalogs.scopeKey, key.scopeKey),
+        ),
+      )
+      .get() ?? null
+  );
+}
+
+export function replaceStoredProviderModelCatalog(
+  db: DbConnection,
+  args: {
+    row: StoredProviderModelCatalog;
+    pruneWorkspaceRowsFetchedBefore: number | null;
+  },
+): void {
+  const { row, pruneWorkspaceRowsFetchedBefore } = args;
+  db.transaction((tx) => {
+    tx.insert(providerModelCatalogs)
+      .values(row)
+      .onConflictDoUpdate({
+        target: [
+          providerModelCatalogs.hostId,
+          providerModelCatalogs.providerId,
+          providerModelCatalogs.scopeKey,
+        ],
+        set: {
+          fingerprint: row.fingerprint,
+          modelsJson: row.modelsJson,
+          selectedOnlyModelsJson: row.selectedOnlyModelsJson,
+          fetchedAt: row.fetchedAt,
+        },
+      })
+      .run();
+    if (pruneWorkspaceRowsFetchedBefore !== null) {
+      tx.delete(providerModelCatalogs)
+        .where(
+          and(
+            eq(providerModelCatalogs.hostId, row.hostId),
+            eq(providerModelCatalogs.providerId, row.providerId),
+            ne(providerModelCatalogs.scopeKey, ""),
+            lt(
+              providerModelCatalogs.fetchedAt,
+              pruneWorkspaceRowsFetchedBefore,
+            ),
+          ),
+        )
+        .run();
+    }
+  });
+}
+
+export function deleteStoredProviderModelCatalogsForHost(
+  db: DbConnection,
+  hostId: string,
+): void {
+  db.delete(providerModelCatalogs)
+    .where(eq(providerModelCatalogs.hostId, hostId))
+    .run();
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1016,6 +1016,26 @@ export const hostDaemonSessions = sqliteTable(
   ],
 );
 
+export const providerModelCatalogs = sqliteTable(
+  "provider_model_catalogs",
+  {
+    hostId: text("host_id")
+      .notNull()
+      .references(() => hosts.id, { onDelete: "cascade" }),
+    providerId: text("provider_id").notNull(),
+    scopeKey: text("scope_key").notNull(),
+    fingerprint: text("fingerprint").notNull(),
+    modelsJson: text("models_json").notNull(),
+    selectedOnlyModelsJson: text("selected_only_models_json").notNull(),
+    fetchedAt: integer("fetched_at").notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.hostId, table.providerId, table.scopeKey],
+    }),
+  ],
+);
+
 export const terminalSessions = sqliteTable(
   "terminal_sessions",
   {

--- a/packages/db/test/data/provider-model-catalogs.test.ts
+++ b/packages/db/test/data/provider-model-catalogs.test.ts
@@ -1,0 +1,139 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createConnection,
+  deleteStoredProviderModelCatalogsForHost,
+  getStoredProviderModelCatalog,
+  hosts,
+  migrate,
+  noopNotifier,
+  providerModelCatalogs,
+  replaceStoredProviderModelCatalog,
+  upsertHost,
+  type DbConnection,
+  type StoredProviderModelCatalog,
+} from "../../src/index.js";
+
+function catalogRow(
+  hostId: string,
+  providerId: string,
+  scopeKey: string,
+  fetchedAt = 1_000,
+): StoredProviderModelCatalog {
+  return {
+    hostId,
+    providerId,
+    scopeKey,
+    fingerprint: `${hostId}-${providerId}-${scopeKey}`,
+    modelsJson: JSON.stringify([{ id: "gpt-5", model: "gpt-5" }]),
+    selectedOnlyModelsJson: "[]",
+    fetchedAt,
+  };
+}
+
+function writeRows(db: DbConnection, rows: StoredProviderModelCatalog[]) {
+  for (const row of rows) {
+    replaceStoredProviderModelCatalog(db, {
+      row,
+      pruneWorkspaceRowsFetchedBefore: null,
+    });
+  }
+}
+
+function listRowKeys(db: DbConnection): string[] {
+  return db
+    .select()
+    .from(providerModelCatalogs)
+    .all()
+    .map((row) => `${row.hostId}|${row.providerId}|${row.scopeKey}`)
+    .sort();
+}
+
+describe("provider model catalogs data", () => {
+  let db: DbConnection;
+
+  beforeEach(() => {
+    db = createConnection(":memory:");
+    migrate(db);
+    upsertHost(db, noopNotifier, { id: "h1", name: "Host 1" });
+    upsertHost(db, noopNotifier, { id: "h2", name: "Host 2" });
+  });
+
+  afterEach(() => {
+    db.$client.close();
+  });
+
+  it("replaces the row for the same key and reads only the exact host, provider and scope", () => {
+    writeRows(db, [
+      catalogRow("h1", "codex", ""),
+      catalogRow("h1", "codex", "/w/a"),
+      catalogRow("h1", "claude-code", ""),
+      catalogRow("h2", "codex", ""),
+    ]);
+    const replacement: StoredProviderModelCatalog = {
+      ...catalogRow("h1", "codex", "", 2_000),
+      fingerprint: "fp-2",
+      selectedOnlyModelsJson: JSON.stringify([
+        { id: "legacy", model: "legacy" },
+      ]),
+    };
+    writeRows(db, [replacement]);
+
+    const key = { hostId: "h1", providerId: "codex", scopeKey: "" };
+    expect(getStoredProviderModelCatalog(db, key)).toEqual(replacement);
+    expect(
+      getStoredProviderModelCatalog(db, { ...key, scopeKey: "/w/a" }),
+    ).toEqual(catalogRow("h1", "codex", "/w/a"));
+    expect(getStoredProviderModelCatalog(db, { ...key, hostId: "h2" })).toEqual(
+      catalogRow("h2", "codex", ""),
+    );
+    expect(
+      getStoredProviderModelCatalog(db, { ...key, scopeKey: "/w/b" }),
+    ).toBeNull();
+    expect(listRowKeys(db)).toEqual([
+      "h1|claude-code|",
+      "h1|codex|",
+      "h1|codex|/w/a",
+      "h2|codex|",
+    ]);
+  });
+
+  it("deletes every row of one host and cascades a deleted host row, keeping other hosts", () => {
+    writeRows(db, [
+      catalogRow("h1", "codex", ""),
+      catalogRow("h1", "pi", "/w/a"),
+      catalogRow("h2", "codex", ""),
+      catalogRow("h2", "pi", "/w/b"),
+    ]);
+
+    deleteStoredProviderModelCatalogsForHost(db, "h1");
+    expect(listRowKeys(db)).toEqual(["h2|codex|", "h2|pi|/w/b"]);
+
+    db.delete(hosts).where(eq(hosts.id, "h2")).run();
+    expect(listRowKeys(db)).toEqual([]);
+  });
+
+  it("prunes only that host and provider's workspace rows older than the cutoff", () => {
+    const cutoff = 10_000;
+    writeRows(db, [
+      catalogRow("h1", "pi", "", 1),
+      catalogRow("h1", "pi", "/w/old", cutoff - 1),
+      catalogRow("h1", "pi", "/w/at-cutoff", cutoff),
+      catalogRow("h1", "opencode", "/w/old", 1),
+      catalogRow("h2", "pi", "/w/old", 1),
+    ]);
+
+    replaceStoredProviderModelCatalog(db, {
+      row: catalogRow("h1", "pi", "/w/current", cutoff + 5_000),
+      pruneWorkspaceRowsFetchedBefore: cutoff,
+    });
+
+    expect(listRowKeys(db)).toEqual([
+      "h1|opencode|/w/old",
+      "h1|pi|",
+      "h1|pi|/w/at-cutoff",
+      "h1|pi|/w/current",
+      "h2|pi|/w/old",
+    ]);
+  });
+});

--- a/packages/db/test/migrate.test.ts
+++ b/packages/db/test/migrate.test.ts
@@ -676,6 +676,7 @@ function dropMarketplaceCatalogSchema(db: DbConnection): void {
 }
 
 function dropEventToolNameColumn(db: DbConnection): void {
+  db.$client.prepare("DROP TABLE IF EXISTS provider_model_catalogs").run();
   db.$client.prepare("DROP TABLE IF EXISTS ui_preferences").run();
   db.$client.prepare("DROP TABLE IF EXISTS retained_event_outputs").run();
   dropThreadConversationOutlinesTable(db);
@@ -841,6 +842,7 @@ function rewindEnvironmentRowFactsMigration(db: DbConnection): void {
 
 function rewindMachineProvidersMigration(db: DbConnection): void {
   db.$client.exec("DROP TABLE IF EXISTS thread_plugin_metadata");
+  db.$client.exec("DROP TABLE IF EXISTS provider_model_catalogs");
   db.$client.exec("DROP TABLE IF EXISTS environment_hook_operations");
   if (
     db.$client
@@ -1712,6 +1714,7 @@ describe("migrate", () => {
       });
       const eventData = JSON.stringify({ message: "existing event" });
 
+      db.$client.prepare("DROP TABLE provider_model_catalogs").run();
       db.$client.prepare("DROP TABLE ui_preferences").run();
       db.$client.prepare("DROP TABLE retained_event_outputs").run();
       db.$client
@@ -5671,6 +5674,7 @@ describe("environment providers migration", () => {
   const environmentProvidersMigrationWhen = 1788386943764;
 
   function seedPreProviderEnvironments(db: DbConnection): void {
+    db.$client.prepare("DROP TABLE provider_model_catalogs").run();
     db.$client.prepare("DROP TABLE ui_preferences").run();
     db.$client.prepare("DROP TABLE retained_event_outputs").run();
     rewindEnvironmentRowFactsMigration(db);

--- a/packages/db/test/query-plans.test.ts
+++ b/packages/db/test/query-plans.test.ts
@@ -45,6 +45,7 @@ import {
   hydrateRetainedEventOutputRows,
 } from "../src/data/retained-event-outputs.js";
 import { getDatabaseMaintenanceActivity } from "../src/data/maintenance.js";
+import { replaceStoredProviderModelCatalog } from "../src/data/provider-model-catalogs.js";
 import { openSession } from "../src/data/sessions.js";
 import {
   listDueScheduledQueuedThreadMessages,
@@ -1596,6 +1597,48 @@ describe("slow query index plans", () => {
     expect(queryPlanDetails({ db, ...statement! })).toContain(
       "events_thread_turn_type_item_sequence_idx",
     );
+
+    db.$client.close();
+  });
+
+  it("prunes stored provider model catalogs through the primary-key prefix", () => {
+    const { db, host, logger } = setup();
+    const pruneWorkspaceRowsFetchedBefore = 10_000;
+    const isCatalogDelete = (fields: SlowDbQueryLogFields): boolean =>
+      fields.operation === "run" &&
+      fields.sql.startsWith('delete from "provider_model_catalogs"');
+    logger.clear();
+
+    replaceStoredProviderModelCatalog(db, {
+      row: {
+        hostId: host.id,
+        providerId: "acp-pi-acp",
+        scopeKey: "/w/current",
+        fingerprint: "catalog-prune-plan",
+        modelsJson: "[]",
+        selectedOnlyModelsJson: "[]",
+        fetchedAt: 20_000,
+      },
+      pruneWorkspaceRowsFetchedBefore,
+    });
+
+    const prune = findOnlyDebugLog({ logger, predicate: isCatalogDelete });
+    const pruneParams = [
+      host.id,
+      "acp-pi-acp",
+      "",
+      pruneWorkspaceRowsFetchedBefore,
+    ];
+    expect(prune.fields.bindingArgumentCount).toBe(pruneParams.length);
+    const pruneDetails = queryPlanDetails({
+      db,
+      params: pruneParams,
+      sql: prune.fields.sql,
+    });
+    expect(pruneDetails).toMatch(
+      /USING (COVERING )?INDEX sqlite_autoindex_provider_model_catalogs_1 \(host_id=\? AND provider_id=\?\)/u,
+    );
+    expect(pruneDetails).not.toMatch(/SCAN provider_model_catalogs/u);
 
     db.$client.close();
   });

--- a/packages/domain/src/change-kinds.ts
+++ b/packages/domain/src/change-kinds.ts
@@ -54,6 +54,7 @@ export type EnvironmentChangeKind = (typeof ENVIRONMENT_CHANGE_KINDS)[number];
 export const HOST_CHANGE_KINDS = [
   "host-connected",
   "host-disconnected",
+  "provider-model-catalog-changed",
 ] as const;
 export type HostChangeKind = (typeof HOST_CHANGE_KINDS)[number];
 

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.87";
+export const PLUGIN_SDK_VERSION = "0.4.88";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.87",
+  "version": "0.4.88",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/provider-bridge-protocol/src/bridge-kit/provider-maintenance-kit.test.ts
+++ b/packages/provider-bridge-protocol/src/bridge-kit/provider-maintenance-kit.test.ts
@@ -1,3 +1,5 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -5,10 +7,30 @@ import {
   formatCommand,
   installationVerification,
   npmGlobalInstallSource,
+  readCliVersion,
   versionFrom,
 } from "./provider-maintenance-kit.js";
 
 describe("provider maintenance kit", () => {
+  it.skipIf(process.platform === "win32")(
+    "reads the version of a CLI that keeps reading stdin until EOF",
+    async () => {
+      const dir = await mkdtemp(path.join(tmpdir(), "bb-cli-version-"));
+      try {
+        const executable = path.join(dir, "stdio-server-cli");
+        await writeFile(
+          executable,
+          '#!/bin/sh\ncat >/dev/null\necho "tool 1.2.3"\n',
+        );
+        await chmod(executable, 0o755);
+        expect(await readCliVersion(executable)).toBe("1.2.3");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+    15_000,
+  );
+
   it("compares the numeric core of CLI versions, prerelease below release", () => {
     expect(compareVersions("0.135.9", "0.136.0")).toBeLessThan(0);
     expect(compareVersions("0.136.0-beta.1", "0.136.0")).toBeLessThan(0);

--- a/packages/provider-bridge-protocol/src/bridge-kit/provider-maintenance-kit.ts
+++ b/packages/provider-bridge-protocol/src/bridge-kit/provider-maintenance-kit.ts
@@ -65,9 +65,11 @@ export function versionFrom(value: string | null): string | null {
 
 export async function readCliVersion(command: string): Promise<string | null> {
   try {
-    const { stdout, stderr } = await execFileAsync(command, ["--version"], {
+    const probe = execFileAsync(command, ["--version"], {
       timeout: CLI_PROBE_TIMEOUT_MS,
     });
+    probe.child.stdin?.end();
+    const { stdout, stderr } = await probe;
     return (
       `${stdout}\n${stderr}`.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/u)?.[0] ??
       null

--- a/packages/templates/src/templates/bb-guide-providers.md
+++ b/packages/templates/src/templates/bb-guide-providers.md
@@ -24,6 +24,10 @@ the explicitly requested provider or Codex, then resolves the model marked
 default by that provider on the target machine (falling back to the first
 catalog model when none is marked).
 
+Model lists answer from the machine's last stored list while a background
+refresh runs, so a list can be hours old. A provider whose refresh keeps
+failing or timing out keeps answering from its last stored list.
+
 Provider-native memory can be controlled on the separate Settings → Providers
 → Codex and Settings → Providers → Claude Code pages. Codex memory controls
 both recall (`memories.use_memories`) and future generation

--- a/plugins/bb-guide/skills/bb-cli/references/thread-creation.md
+++ b/plugins/bb-guide/skills/bb-cli/references/thread-creation.md
@@ -157,7 +157,10 @@ environment pull-request show <id>`. Diff commands require an explicit target
   and `bb provider models <provider-id>`. Both accept `--machine <id-or-name>`
   (alias `--host`) or `--environment <id>` to inspect the machine where work
   will run; the selectors cannot be combined. With neither selector they
-  intentionally inspect the primary machine.
+  intentionally inspect the primary machine. Model lists answer from the
+  machine's last stored list while a background refresh runs, so a list can be
+  hours old. A provider whose refresh keeps failing or timing out keeps
+  answering from its last stored list.
 - Top-level `customModels` in the same `config.json` registers extra picker
   models. Use a provider ID returned by the target host's catalog. Acceptance
   of unlisted models is provider-specific; consult that provider's skill.

--- a/plugins/concurrency-limit/server.test.ts
+++ b/plugins/concurrency-limit/server.test.ts
@@ -107,17 +107,20 @@ async function setup(options: SetupOptions = {}) {
 }
 
 function hostChanges(): {
-  emitHostConnected(hostId: string): void;
+  emitHostChanges(
+    hostId: string,
+    changes: Parameters<HostChangedSubscription["callback"]>[0]["changes"],
+  ): void;
   subscribe: BbPluginApi["sdk"]["subscribe"];
 } {
   let callback: HostChangedSubscription["callback"] | null = null;
   return {
-    emitHostConnected(hostId) {
+    emitHostChanges(hostId, changes) {
       callback?.({
         type: "changed",
         entity: "host",
         id: hostId,
-        changes: ["host-connected"],
+        changes,
       });
     },
     subscribe(subscription) {
@@ -264,10 +267,38 @@ describe("configuration", () => {
     expect(harness.experimental_hostRpcCalls).toHaveLength(0);
 
     status = "connected";
-    changes.emitHostConnected("host-a");
+    changes.emitHostChanges("host-a", ["host-connected"]);
     await vi.waitFor(() => {
       expect(harness.experimental_hostRpcCalls).toHaveLength(1);
     });
+
+    service.controller.abort();
+    await service.done;
+  });
+
+  it("ignores host messages that only report a provider model catalog change", async () => {
+    const changes = hostChanges();
+    const { harness } = await setup({
+      hosts: [hostRecord("host-a")],
+      subscribe: changes.subscribe,
+    });
+    const service = harness.behavior.runService("capacity-detector");
+    await vi.waitFor(() => {
+      expect(harness.experimental_hostRpcCalls).toHaveLength(1);
+      expect(harness.realtimeSignals).toHaveLength(1);
+    });
+    const hostListCalls = harness.inspection.sdk.callsTo("hosts.list").length;
+
+    changes.emitHostChanges("host-a", ["provider-model-catalog-changed"]);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(harness.realtimeSignals).toHaveLength(1);
+    expect(harness.experimental_hostRpcCalls).toHaveLength(1);
+    expect(harness.inspection.sdk.callsTo("hosts.list")).toHaveLength(
+      hostListCalls,
+    );
+
+    changes.emitHostChanges("host-a", ["host-disconnected"]);
+    expect(harness.realtimeSignals).toHaveLength(2);
 
     service.controller.abort();
     await service.done;

--- a/plugins/concurrency-limit/server.ts
+++ b/plugins/concurrency-limit/server.ts
@@ -449,7 +449,13 @@ export default async function concurrencyLimitPlugin(
       const unsubscribeHost = bb.sdk.subscribe({
         event: "host:changed",
         callback: (event) => {
-          bb.realtime.publish(CONFIGURATION_CHANGED_CHANNEL, {});
+          if (
+            event.changes.some(
+              (change) =>
+                change === "host-connected" || change === "host-disconnected",
+            )
+          )
+            bb.realtime.publish(CONFIGURATION_CHANGED_CHANNEL, {});
           if (event.changes.includes("host-connected"))
             requestRefresh(event.id);
         },


### PR DESCRIPTION
## Human comments

## What was wrong

The model picker waited for a provider model-list RPC whenever its server cache was empty or invalidated, including after daemon reconnects and server restarts. Slow provider discovery delayed the selected-model label and provider tabs, while reconnects could briefly show “Could not load models.”

## What changed

- Persist the last successful model catalog per machine, provider, and scope. Serve stored catalogs immediately and refresh in the background after 10 minutes; cold reads wait for discovery. Preserve the last good list through transient failures, while surfacing authentication and missing-executable errors.
- Prewarm eligible catalogs on daemon connection and provider registration changes, with bounded concurrency and without waking suspended machines. Execution overrides and model recovery refresh older catalogs before rejecting an unknown model.
- Prefetch sibling providers when the picker opens, refresh composers on targeted catalog-change events, and avoid execution-option refetches on disconnect. Refresh installed-provider health in the background and close CLI-version probe stdin so stdio CLIs can exit promptly.
- Add the catalog table and generated migration, update provider documentation and CLI guidance, and bump the Plugin SDK version for the host catalog-change event. No server/daemon wire fields change.

Accepted limitations: SDK, CLI, and workflow validation can temporarily reject newly released models until catalog refresh; repeated transient failures can retain the last good list indefinitely. A restart failure received before socket closure can delay retries, and a refresh racing machine-variable propagation can store the previous list as fresh. Review also identified a background health result surviving provider re-registration for up to five minutes, and a redundant startup prewarm pass (production warming happens when daemons connect).

## How you verified

The completed verification on this unchanged commit included:

- `pnpm exec turbo run build typecheck lint --continue`: 149/149 tasks passed.
- `pnpm exec turbo run test --filter=@bb/server --concurrency=2`: 2,633 tests passed.
- App, database, SDK, and integration suites; tarball smoke test and SDK checks passed.
- Catalog persistence, refresh/failure behavior, prewarm concurrency, reconnect handling, and picker prefetch coverage. Prewarm, registry, and execution-options tests passed five consecutive runs (66 tests per run).
- Dev-app measurements: stored reads 5–8 ms, all-provider read 15 ms, cold composer label 38 ms, first tab clicks 8–48 ms, and no model-loading error displayed during the measured daemon restart.

Before publication, confirmed the branch is one commit ahead of current `origin/main`, the working tree is clean, and `git diff --check origin/main...HEAD` passes.

> AGENT GENERATED
