### PR TITLE
Open palette search results in splits

### DIFF
--- a/apps/app/src/components/commands/CommandPalette.test.tsx
+++ b/apps/app/src/components/commands/CommandPalette.test.tsx
@@ -303,7 +303,6 @@ function makeThread(
 }
 
 function renderPalette({
-  onSplit,
   compact = false,
   layout = {
     root: {
@@ -314,7 +313,6 @@ function renderPalette({
     focusedPaneId: "origin",
   },
 }: {
-  onSplit?: () => void;
   compact?: boolean;
   layout?: SplitLayout | null;
 } = {}) {
@@ -335,11 +333,7 @@ function renderPalette({
             <Handler command="terminal.open" />
             <Handler command="composer.focus" />
             <Handler command="browser.reload" />
-            <CommandPalette
-              threadId={null}
-              projectId={null}
-              onSplit={onSplit}
-            />
+            <CommandPalette threadId={null} projectId={null} />
             <LocationProbe />
           </AppCommandProvider>
         </MemoryRouter>
@@ -1381,27 +1375,6 @@ describe("CommandPalette", () => {
     await waitFor(() => expect(testState.calls).toEqual(["panel.toggle"]));
     expect(screen.queryByRole("combobox")).toBeNull();
     expect(document.activeElement).toBe(screen.getByTestId("origin"));
-  });
-
-  it("runs Split as an internal palette action without an app command", async () => {
-    const onSplit = vi.fn();
-    renderPalette({ onSplit });
-    openPalette();
-    await waitFor(() => expect(searchField()).toBeTruthy());
-
-    const splitRow = within(bucketGroup("Actions"))
-      .getAllByRole("option")
-      .find((row) => row.textContent?.includes("Split"));
-    expect(splitRow?.textContent).not.toContain("Window and layout");
-
-    fireEvent.change(searchField(), { target: { value: "split" } });
-    await waitFor(() =>
-      expect(selectedOption()?.textContent).toContain("Split"),
-    );
-    fireEvent.keyDown(searchField(), { key: "Enter" });
-
-    await waitFor(() => expect(onSplit).toHaveBeenCalledOnce());
-    expect(testState.calls).toEqual([]);
   });
 
   it("keeps the default catalog unchanged after running a command", async () => {

--- a/apps/app/src/components/commands/CommandPalette.test.tsx
+++ b/apps/app/src/components/commands/CommandPalette.test.tsx
@@ -11,6 +11,8 @@ import {
 } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { createStore, Provider } from "jotai";
+import { splitLayoutAtom } from "@/lib/split-layout/atoms";
+import { MAX_PANES, type SplitLayout } from "@/lib/split-layout";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   defaultAppSettings,
@@ -109,6 +111,7 @@ const modeState = vi.hoisted(() => ({
   recentError: false,
   searchLoading: false,
 }));
+const openThreadInSplitMock = vi.hoisted(() => vi.fn());
 const routeNavigateMock = vi.hoisted(() => vi.fn());
 
 function expectClasses(
@@ -189,6 +192,10 @@ vi.mock("@/lib/app-query-client", () => ({
   appQueryClient: {
     fetchQuery: () => Promise.resolve(testState.plugins),
   },
+}));
+
+vi.mock("@/lib/split-layout/openThreadInSplit", () => ({
+  openThreadInSplit: openThreadInSplitMock,
 }));
 
 vi.mock("@/components/ui/app-route-anchor", () => ({
@@ -295,8 +302,24 @@ function makeThread(
   };
 }
 
-function renderPalette({ compact = false }: { compact?: boolean } = {}) {
+function renderPalette({
+  onSplit,
+  compact = false,
+  layout = {
+    root: {
+      type: "pane",
+      paneId: "origin",
+      content: { kind: "thread", projectId: "project-1", threadId: "origin" },
+    },
+    focusedPaneId: "origin",
+  },
+}: {
+  onSplit?: () => void;
+  compact?: boolean;
+  layout?: SplitLayout | null;
+} = {}) {
   const store = createStore();
+  store.set(splitLayoutAtom, layout);
   const result = render(
     <Provider store={store}>
       <CompactViewportOverrideProvider isCompactViewport={compact}>
@@ -315,6 +338,7 @@ function renderPalette({ compact = false }: { compact?: boolean } = {}) {
             <CommandPalette
               threadId={null}
               projectId={null}
+              onSplit={onSplit}
             />
             <LocationProbe />
           </AppCommandProvider>
@@ -360,6 +384,15 @@ const selectedOption = () =>
     .getAllByRole("option")
     .find((option) => option.getAttribute("aria-selected") === "true");
 
+async function requestShortcutHints() {
+  fireEvent.keyDown(window, { key: "Control", ctrlKey: true });
+  await waitFor(
+    () =>
+      expect(document.querySelector("[data-palette-footer]")).not.toBeNull(),
+    { timeout: 1500 },
+  );
+}
+
 afterEach(() => {
   cleanup();
   removePluginSlotRegistrations("linear");
@@ -375,6 +408,7 @@ afterEach(() => {
   modeState.recentLoading = false;
   modeState.recentError = false;
   modeState.searchLoading = false;
+  openThreadInSplitMock.mockReset();
   routeNavigateMock.mockReset();
   window.localStorage.clear();
 });
@@ -522,8 +556,55 @@ describe("CommandPalette", () => {
       "data-tab-pill-close",
     );
     expect(screen.queryByRole("button", { name: "Thread scope" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Open in split" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Open in split" })).toBeTruthy();
     expect(document.querySelector("[data-palette-footer]")).toBeNull();
+    await requestShortcutHints();
+    const footer = screen
+      .getByTestId("command-palette")
+      .querySelector("[data-palette-footer]");
+    expectClasses(
+      footer,
+      "flex-wrap",
+      "bg-surface-recessed-soft-solid",
+      "border-border/40",
+      "px-3",
+      "py-2",
+    );
+    expectAttribute(footer, "aria-hidden", "true");
+    for (const keycap of footer?.querySelectorAll("kbd") ?? []) {
+      expectClasses(
+        keycap,
+        "rounded-sm",
+        "bg-state-hover",
+        "font-sans",
+        "font-normal",
+        "tabular-nums",
+        "text-subtle-foreground",
+        "opacity-60",
+      );
+      expectNoClasses(
+        keycap,
+        "border-border/70",
+        "bg-background/70",
+        "font-mono",
+        "text-muted-foreground",
+        "shadow-xs",
+      );
+    }
+    for (const label of footer?.querySelectorAll(
+      "[data-palette-footer-label]",
+    ) ?? []) {
+      expectClasses(label, "text-subtle-foreground");
+      expectNoClasses(label, "opacity-50");
+      expectClasses(
+        label.closest("[data-palette-footer]"),
+        "text-subtle-foreground",
+      );
+    }
+    expect(footer?.textContent).not.toContain("Backspace");
+    expect(footer?.textContent).not.toContain("Select");
+    expect(footer?.textContent).not.toContain("Esc");
+    expectText(footer, "Open in split");
     const threadInput = screen.getByRole("combobox", {
       name: "Search threads",
     });
@@ -531,7 +612,7 @@ describe("CommandPalette", () => {
     expect(threadDescriptionId).not.toBeNull();
     expectText(
       document.getElementById(threadDescriptionId ?? ""),
-      "Use Escape to return to commands.",
+      "Use Command-Enter or Control-Enter to open the selected thread in a split. Use Escape to return to commands.",
     );
 
     fireEvent.keyDown(screen.getByRole("combobox"), { key: "Escape" });
@@ -634,6 +715,7 @@ describe("CommandPalette", () => {
       ).toBeTruthy();
       expect(testState.calls).toEqual([]);
       expect(routeNavigateMock).not.toHaveBeenCalled();
+      expect(openThreadInSplitMock).not.toHaveBeenCalled();
     },
   );
 
@@ -656,6 +738,147 @@ describe("CommandPalette", () => {
           .getByTestId("command-palette")
           .querySelector("[data-palette-footer]"),
       ).toBeNull();
+    },
+  );
+
+  it("reveals split guidance on demand and hides it on release, action focus, no matches, and Commands", async () => {
+    modeState.activeRecents = [makeThread("selected")];
+    renderPalette();
+    openThreadSearch();
+    await screen.findByRole("option");
+    const palette = screen.getByTestId("command-palette");
+    expect(palette.querySelector("[data-palette-footer]")).toBeNull();
+    await requestShortcutHints();
+    expect(
+      palette.querySelector("[data-palette-footer]")?.textContent,
+    ).toContain("Ctrl+↵");
+    fireEvent.keyUp(window, { key: "Control" });
+    expect(palette.querySelector("[data-palette-footer]")).toBeNull();
+    await requestShortcutHints();
+    const split = screen.getByRole("button", { name: "Open in split" });
+    act(() => split.focus());
+    expect(palette.querySelector("[data-palette-footer]")).toBeNull();
+    act(() => searchField().focus());
+    await requestShortcutHints();
+    expect(
+      palette.querySelector("[data-palette-footer]")?.textContent,
+    ).not.toContain("Esc");
+    fireEvent.change(searchField(), { target: { value: "no match" } });
+    await screen.findByText("No matching threads");
+    expectClasses(
+      screen.getByText("No matching threads").parentElement,
+      "px-3",
+      "py-4",
+    );
+    expect(palette.querySelector("[data-palette-footer]")).toBeNull();
+    expect(searchField().hasAttribute("aria-activedescendant")).toBe(false);
+    fireEvent.keyDown(searchField(), { key: "Enter", ctrlKey: true });
+    expect(openThreadInSplitMock).not.toHaveBeenCalled();
+    fireEvent.change(searchField(), { target: { value: "" } });
+    await screen.findByRole("option");
+    fireEvent.keyDown(searchField(), { key: "Escape" });
+    await screen.findByRole("combobox", { name: "Search commands" });
+    expect(palette.querySelector("[data-palette-footer]")).toBeNull();
+  });
+
+  it("omits split guidance while searching and on compact layouts", async () => {
+    modeState.activeRecents = [makeThread("selected")];
+    modeState.searchLoading = true;
+    renderPalette({ compact: true });
+    openThreadSearch();
+    await screen.findByRole("combobox", { name: "Search threads" });
+    expect(screen.queryByRole("button", { name: "Open in split" })).toBeNull();
+    expect(
+      screen
+        .getByTestId("command-palette")
+        .querySelector("[data-palette-footer]"),
+    ).toBeNull();
+    fireEvent.change(searchField(), { target: { value: "search" } });
+    await screen.findByText("Searching threads");
+    expect(
+      screen
+        .getByTestId("command-palette")
+        .querySelector("[data-palette-footer]"),
+    ).toBeNull();
+  });
+
+  it("keeps the split action discoverable with keyboard hints disabled", async () => {
+    testState.showKeyboardHints = false;
+    modeState.activeRecents = [
+      makeThread("first"),
+      makeThread("second", { updatedAt: 1 }),
+    ];
+    renderPalette();
+    openThreadSearch();
+    await screen.findByRole("option", { name: /Title first/ });
+    fireEvent.keyDown(window, { key: "Control", ctrlKey: true });
+    await act(() => new Promise((resolve) => setTimeout(resolve, 800)));
+    expect(document.querySelector("[data-palette-footer]")).toBeNull();
+    fireEvent.keyUp(window, { key: "Control" });
+    fireEvent.keyDown(searchField(), { key: "ArrowDown" });
+    const action = screen.getByRole("button", { name: "Open in split" });
+    expectAttribute(action, "aria-disabled", "false");
+    expect(action.closest('[role="listbox"]')).toBeNull();
+    fireEvent.click(action);
+    await waitFor(() =>
+      expect(openThreadInSplitMock).toHaveBeenCalledWith(
+        expect.objectContaining({ threadId: "second" }),
+      ),
+    );
+    expect(openThreadInSplitMock).toHaveBeenCalledTimes(1);
+    expect(routeNavigateMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["missing workspace", "already open", "pane limit"])(
+    "removes split guidance and disables the action for %s",
+    async (state) => {
+      modeState.activeRecents = [makeThread("selected")];
+      const { store } = renderPalette();
+      openThreadSearch();
+      await screen.findByRole("option");
+      await requestShortcutHints();
+      const layout: SplitLayout = {
+        root: {
+          type: "split",
+          dir: "row",
+          sizes: Array(MAX_PANES).fill(1 / MAX_PANES),
+          children: Array.from({ length: MAX_PANES }, (_, index) => ({
+            type: "pane",
+            paneId: `pane-${index}`,
+            content: {
+              kind: "thread",
+              projectId: "project-1",
+              threadId:
+                state === "already open" && index === 0
+                  ? "selected"
+                  : `other-${index}`,
+            },
+          })),
+        },
+        focusedPaneId: "pane-0",
+      };
+      act(() =>
+        store.set(
+          splitLayoutAtom,
+          state === "missing workspace" ? null : layout,
+        ),
+      );
+      expect(document.querySelector("[data-palette-footer]")).toBeNull();
+      const action = screen.getByRole("button", { name: "Open in split" });
+      expectAttribute(action, "aria-disabled", "true");
+      fireEvent.click(action);
+      expect(openThreadInSplitMock).not.toHaveBeenCalled();
+      expect(screen.getByRole("combobox")).toBeTruthy();
+      act(() => action.focus());
+      const tooltip = await screen.findByRole("tooltip");
+      expectText(
+        tooltip,
+        state === "missing workspace"
+          ? "Open a thread first"
+          : state === "already open"
+            ? "Already open"
+            : "Close a split pane first",
+      );
     },
   );
 
@@ -909,7 +1132,40 @@ describe("CommandPalette", () => {
     },
   );
 
-  it("opens an archived message match with its anchor", async () => {
+  it("opens a persisted thread result in a split with Command-Enter", async () => {
+    modeState.searchResponse = {
+      active: {
+        total: 1,
+        results: [{ thread: makeThread("matching-split"), matches: [] }],
+      },
+      archived: { total: 0, results: [] },
+    };
+    renderPalette();
+    openThreadSearch();
+    const input = await screen.findByRole("combobox", {
+      name: "Search threads",
+    });
+    fireEvent.change(input, { target: { value: "match" } });
+    await waitFor(() =>
+      expect(screen.getByRole("option").textContent).toContain(
+        "matching-split",
+      ),
+    );
+
+    fireEvent.keyDown(input, { key: "Enter", metaKey: true });
+
+    await waitFor(() => expect(openThreadInSplitMock).toHaveBeenCalledTimes(1));
+    expect(openThreadInSplitMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "project-1",
+        threadId: "matching-split",
+      }),
+    );
+  });
+
+  it.each([false, true])(
+    "opens an archived message match with its anchor (split=%s)",
+    async (split) => {
       modeState.searchResponse = {
         active: { total: 0, results: [] },
         archived: {
@@ -940,18 +1196,31 @@ describe("CommandPalette", () => {
       expect(
         screen.getByRole("option").querySelector("mark")?.textContent,
       ).toBe("matching");
-      fireEvent.keyDown(input, { key: "Enter" });
+      fireEvent.keyDown(input, { key: "Enter", metaKey: split });
 
       const state = {
         searchMessageSeq: 42,
         searchThreadId: "archived-message",
       };
       await waitFor(() => expect(screen.queryByRole("combobox")).toBeNull());
-      expect(routeNavigateMock).toHaveBeenCalledWith(
-        "/projects/project-1/threads/archived-message",
-        { state },
-      );
-  });
+      if (split) {
+        expect(openThreadInSplitMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            projectId: "project-1",
+            threadId: "archived-message",
+            state,
+          }),
+        );
+        expect(routeNavigateMock).not.toHaveBeenCalled();
+      } else {
+        expect(routeNavigateMock).toHaveBeenCalledWith(
+          "/projects/project-1/threads/archived-message",
+          { state },
+        );
+        expect(openThreadInSplitMock).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it("filters as the user types and keeps the selection on a live row", async () => {
     renderPalette();
@@ -1112,6 +1381,27 @@ describe("CommandPalette", () => {
     await waitFor(() => expect(testState.calls).toEqual(["panel.toggle"]));
     expect(screen.queryByRole("combobox")).toBeNull();
     expect(document.activeElement).toBe(screen.getByTestId("origin"));
+  });
+
+  it("runs Split as an internal palette action without an app command", async () => {
+    const onSplit = vi.fn();
+    renderPalette({ onSplit });
+    openPalette();
+    await waitFor(() => expect(searchField()).toBeTruthy());
+
+    const splitRow = within(bucketGroup("Actions"))
+      .getAllByRole("option")
+      .find((row) => row.textContent?.includes("Split"));
+    expect(splitRow?.textContent).not.toContain("Window and layout");
+
+    fireEvent.change(searchField(), { target: { value: "split" } });
+    await waitFor(() =>
+      expect(selectedOption()?.textContent).toContain("Split"),
+    );
+    fireEvent.keyDown(searchField(), { key: "Enter" });
+
+    await waitFor(() => expect(onSplit).toHaveBeenCalledOnce());
+    expect(testState.calls).toEqual([]);
   });
 
   it("keeps the default catalog unchanged after running a command", async () => {

--- a/apps/app/src/components/commands/CommandPalette.tsx
+++ b/apps/app/src/components/commands/CommandPalette.tsx
@@ -76,11 +76,13 @@ function invocationTarget(invocation: {
 export interface CommandPaletteProps {
   threadId: string | null;
   projectId: string | null;
+  onSplit?: () => void;
 }
 
 export function CommandPalette({
   threadId,
   projectId,
+  onSplit,
 }: CommandPaletteProps) {
   const navigate = useNavigate();
   const runner = useAppCommandRunner();
@@ -137,6 +139,18 @@ export function CommandPalette({
         dispatch: runner.dispatch,
         shortcuts,
       }),
+      ...(onSplit === undefined
+        ? []
+        : [
+            {
+              id: "internal:thread.split",
+              bucket: "Actions",
+              group: "Window and layout",
+              title: "Split",
+              shortcut: null,
+              run: onSplit,
+            } satisfies PaletteAction,
+          ]),
       ...buildPluginPaletteActions({
         slots: pluginSlots.commandPaletteActions,
         threadId,
@@ -150,6 +164,7 @@ export function CommandPalette({
       runner.isCommandAvailable,
       shortcuts,
       threadId,
+      onSplit,
       pluginSlots.commandPaletteActions,
     ],
   );
@@ -348,6 +363,7 @@ export function CommandPalette({
                 ? undefined
                 : `${optionIdPrefix}-${activeIndex}`
             }
+            footerKeys={[]}
             inputDescription={PALETTE_INPUT_DESCRIPTION}
             inputLabel={PALETTE_INPUT_LABEL}
             listId={listId}

--- a/apps/app/src/components/commands/CommandPalette.tsx
+++ b/apps/app/src/components/commands/CommandPalette.tsx
@@ -76,13 +76,11 @@ function invocationTarget(invocation: {
 export interface CommandPaletteProps {
   threadId: string | null;
   projectId: string | null;
-  onSplit?: () => void;
 }
 
 export function CommandPalette({
   threadId,
   projectId,
-  onSplit,
 }: CommandPaletteProps) {
   const navigate = useNavigate();
   const runner = useAppCommandRunner();
@@ -139,18 +137,6 @@ export function CommandPalette({
         dispatch: runner.dispatch,
         shortcuts,
       }),
-      ...(onSplit === undefined
-        ? []
-        : [
-            {
-              id: "internal:thread.split",
-              bucket: "Actions",
-              group: "Window and layout",
-              title: "Split",
-              shortcut: null,
-              run: onSplit,
-            } satisfies PaletteAction,
-          ]),
       ...buildPluginPaletteActions({
         slots: pluginSlots.commandPaletteActions,
         threadId,
@@ -164,7 +150,6 @@ export function CommandPalette({
       runner.isCommandAvailable,
       shortcuts,
       threadId,
-      onSplit,
       pluginSlots.commandPaletteActions,
     ],
   );

--- a/apps/app/src/components/commands/PaletteShell.tsx
+++ b/apps/app/src/components/commands/PaletteShell.tsx
@@ -1,5 +1,6 @@
 import {
   useId,
+  useState,
   type KeyboardEventHandler,
   type ReactNode,
   type Ref,
@@ -7,9 +8,16 @@ import {
 import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import { Icon } from "@bb/shared-ui/icon";
 import { TooltipProvider } from "@bb/shared-ui/tooltip";
+import { cn } from "@bb/shared-ui/lib/utils";
 import { useScrollOverflowState } from "@/components/thread/timeline/useScrollOverflowState";
 import { TabPill } from "@/components/ui/tab-pill";
+import { APP_COMMAND_ACCESSORY_PILL_CLASS } from "./AppCommandShortcutHint";
+import { useIsAppCommandModifierHeld } from "./AppCommandProvider";
 
+export const PALETTE_FOOTER_KEYCAP_CLASS = cn(
+  APP_COMMAND_ACCESSORY_PILL_CLASS,
+  "min-w-5 py-0.5",
+);
 export const PALETTE_FOOTER_LABEL_CLASS = "text-subtle-foreground opacity-70";
 
 interface PaletteModeChipProps {
@@ -21,7 +29,9 @@ interface PaletteModeChipProps {
 
 interface PaletteShellProps {
   activeDescendantId?: string;
+  accessory?: ReactNode;
   children: ReactNode;
+  footerKeys: readonly { keys: readonly string[]; label: string }[];
   inputDescription: string;
   inputLabel: string;
   inputRef?: Ref<HTMLInputElement>;
@@ -37,7 +47,9 @@ interface PaletteShellProps {
 
 export function PaletteShell({
   activeDescendantId,
+  accessory,
   children,
+  footerKeys,
   inputDescription,
   inputLabel,
   inputRef,
@@ -51,6 +63,9 @@ export function PaletteShell({
   value,
 }: PaletteShellProps) {
   const inputDescriptionId = useId();
+  const [inputFocused, setInputFocused] = useState(false);
+  const modifierHeld = useIsAppCommandModifierHeld();
+  const showFooter = inputFocused && modifierHeld && footerKeys.length > 0;
   const overflow = useScrollOverflowState<HTMLDivElement>({
     measureOverflow: true,
   });
@@ -87,15 +102,21 @@ export function PaletteShell({
             placeholder={placeholder}
             value={value}
             onChange={(event) => onInputChange(event.target.value)}
+            onFocus={() => setInputFocused(true)}
+            onBlur={() => setInputFocused(false)}
             onKeyDown={onInputKeyDown}
           />
           <span id={inputDescriptionId} className="sr-only">
             {inputDescription}
           </span>
+          {accessory}
         </div>
       </div>
       <div
-        className="relative min-h-0 overflow-hidden rounded-b-[inherit] bg-background"
+        className={cn(
+          "relative min-h-0 overflow-hidden bg-background",
+          !showFooter && "rounded-b-[inherit]",
+        )}
         data-palette-results-clip
       >
         <div
@@ -125,6 +146,30 @@ export function PaletteShell({
           />
         </div>
       </div>
+      {!showFooter ? null : (
+        <div
+          aria-hidden
+          className="relative z-10 flex flex-wrap items-center gap-x-4 gap-y-1 rounded-b-[inherit] border-t border-border/40 bg-surface-recessed-soft-solid px-3 py-2 text-xs text-subtle-foreground"
+          data-palette-footer
+        >
+          {footerKeys.map((hint) => (
+            <span
+              key={`${hint.keys.join(":")}:${hint.label}`}
+              className="inline-flex items-center gap-1.5"
+            >
+              <kbd className={PALETTE_FOOTER_KEYCAP_CLASS}>
+                {hint.keys.join(" / ")}
+              </kbd>
+              <span
+                className="text-subtle-foreground"
+                data-palette-footer-label
+              >
+                {hint.label}
+              </span>
+            </span>
+          ))}
+        </div>
+      )}
     </TooltipProvider>
   );
 }

--- a/apps/app/src/components/commands/ThreadSearchPaletteMode.tsx
+++ b/apps/app/src/components/commands/ThreadSearchPaletteMode.tsx
@@ -9,7 +9,11 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
+import { useAtomValue, useStore } from "jotai";
+import { Button } from "@bb/shared-ui/button";
 import { Icon } from "@bb/shared-ui/icon";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
+import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { CHROME_SECTION_LABEL_CLASS } from "@bb/shared-ui/chrome-style-tokens";
 import {
@@ -38,6 +42,10 @@ import {
   ThreadListEmptyState,
 } from "@/components/thread/ThreadListEmptyState";
 import { getThreadRoutePath } from "@/lib/route-paths";
+import { openThreadInSplit } from "@/lib/split-layout/openThreadInSplit";
+import { splitLayoutAtom } from "@/lib/split-layout/atoms";
+import { countPanes, findPaneByContent, MAX_PANES } from "@/lib/split-layout";
+import { isMacKeyboardPlatform } from "@bb/domain";
 import {
   buildPaletteThreadSearchRows,
   type PaletteThreadSearchRow,
@@ -55,7 +63,10 @@ export function ThreadSearchPaletteMode({
   const optionIdPrefix = useId();
   const inputRef = useRef<HTMLInputElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
+  const store = useStore();
+  const splitLayout = useAtomValue(splitLayoutAtom);
   const navigate = useRouteNavigate();
+  const isCompact = useIsCompactViewport();
   const [query, setQuery] = useState("");
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [now] = useState(() => Date.now());
@@ -117,6 +128,26 @@ export function ThreadSearchPaletteMode({
     !hasLoadError;
   const activeDescendantId =
     activeIndex < 0 ? undefined : `${optionIdPrefix}-${activeIndex}`;
+  const activeRow = result.rows[activeIndex];
+  const splitDisabledReason =
+    splitLayout === null
+      ? "Open a thread first to use split view"
+      : activeRow !== undefined &&
+          findPaneByContent(splitLayout.root, {
+            kind: "thread",
+            projectId: activeRow.projectId,
+            threadId: activeRow.threadId,
+          }) !== null
+        ? "Already open in this workspace"
+        : countPanes(splitLayout.root) >= MAX_PANES
+          ? "Close a split pane first"
+          : null;
+  const canSplit =
+    activeRow !== undefined && !isCompact && splitDisabledReason === null;
+  const splitShortcut = isMacKeyboardPlatform(navigator.platform)
+    ? "⌘↵"
+    : "Ctrl+↵";
+
   const scrollOnNextHighlightRef = useRef(false);
   useEffect(() => {
     if (!scrollOnNextHighlightRef.current) return;
@@ -127,7 +158,7 @@ export function ThreadSearchPaletteMode({
   }, [activeIndex]);
 
   const openRow = useCallback(
-    (row: PaletteThreadSearchRow) => {
+    (row: PaletteThreadSearchRow, split: boolean) => {
       runAfterClose(() => {
         const state =
           row.messageSeq === null
@@ -136,6 +167,17 @@ export function ThreadSearchPaletteMode({
                 searchMessageSeq: row.messageSeq,
                 searchThreadId: row.threadId,
               };
+        if (split) {
+          openThreadInSplit({
+            store,
+            navigate,
+            projectId: row.projectId,
+            threadId: row.threadId,
+            isCompact,
+            state,
+          });
+          return;
+        }
         navigate(
           getThreadRoutePath({
             projectId: row.projectId,
@@ -145,7 +187,7 @@ export function ThreadSearchPaletteMode({
         );
       });
     },
-    [navigate, runAfterClose],
+    [isCompact, navigate, runAfterClose, store],
   );
 
   const handleInputKeyDown = useCallback(
@@ -185,7 +227,7 @@ export function ThreadSearchPaletteMode({
         const row = result.rows[activeIndex];
         if (row === undefined) return;
         event.preventDefault();
-        openRow(row);
+        openRow(row, event.metaKey || event.ctrlKey);
       }
     },
     [activeIndex, onExit, openRow, query.length, result.rows],
@@ -215,7 +257,49 @@ export function ThreadSearchPaletteMode({
   return (
     <PaletteShell
       activeDescendantId={activeDescendantId}
-      inputDescription={presentation.inputDescription}
+      accessory={
+        <>
+          {activeRow === undefined || isCompact ? null : (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="shrink-0 px-2 text-subtle-foreground aria-disabled:opacity-50"
+                  aria-label="Open in split"
+                  aria-disabled={!canSplit}
+                  aria-keyshortcuts={
+                    canSplit ? "Meta+Enter Control+Enter" : undefined
+                  }
+                  onClick={() => {
+                    if (canSplit) openRow(activeRow, true);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Escape") return;
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onExit();
+                  }}
+                >
+                  <Icon name="Columns2" aria-hidden />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {splitDisabledReason ?? `Open in split (${splitShortcut})`}
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </>
+      }
+      footerKeys={
+        canSplit ? [{ keys: [splitShortcut], label: "Open in split" }] : []
+      }
+      inputDescription={
+        canSplit
+          ? presentation.inputDescription
+          : "Use Escape to return to commands."
+      }
       inputLabel="Search threads"
       inputRef={inputRef}
       listId={listId}
@@ -248,7 +332,7 @@ export function ThreadSearchPaletteMode({
             isActive={index === activeIndex}
             row={row}
             onActivate={() => setHighlightedIndex(index)}
-            onSelect={() => openRow(row)}
+            onSelect={() => openRow(row, false)}
           />
         ))
       ) : showThreadListEmptyState ||

--- a/apps/app/src/lib/command-palette/palette-modes.ts
+++ b/apps/app/src/lib/command-palette/palette-modes.ts
@@ -8,7 +8,7 @@ export const PALETTE_MODES: readonly PaletteModeRegistration[] = [
     chip: { icon: "Search", label: "Threads" },
     placeholder: "Search title, project, or message…",
     inputDescription:
-      "Use Escape to return to commands.",
+      "Use Command-Enter or Control-Enter to open the selected thread in a split. Use Escape to return to commands.",
     View: ThreadSearchPaletteMode,
   },
 ];

--- a/apps/app/src/lib/split-layout/openThreadInSplit.test.ts
+++ b/apps/app/src/lib/split-layout/openThreadInSplit.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { openThreadInSplit } from "./openThreadInSplit";
+import type { SplitLayout } from "./index";
+
+function layout(threadId = "thread-1"): SplitLayout {
+  return {
+    root: {
+      type: "pane",
+      paneId: "pane-1",
+      content: { kind: "thread", projectId: "project-1", threadId },
+    },
+    focusedPaneId: "pane-1",
+  };
+}
+
+describe("openThreadInSplit", () => {
+  it("preserves search deep-link state when creating a split", () => {
+    let current = layout();
+    const navigate = vi.fn();
+    openThreadInSplit({
+      store: {
+        get: () => current,
+        set: (_atom, value) => {
+          current = value;
+        },
+      },
+      navigate,
+      projectId: "project-1",
+      threadId: "thread-2",
+      isCompact: false,
+      state: { searchMessageSeq: 42, searchThreadId: "thread-2" },
+    });
+
+    expect(current.root.type).toBe("split");
+    expect(navigate).toHaveBeenCalledWith(
+      "/projects/project-1/threads/thread-2",
+      {
+        state: { searchMessageSeq: 42, searchThreadId: "thread-2" },
+      },
+    );
+  });
+
+  it("keeps replace semantics and state when the result is already open", () => {
+    const current = layout("thread-2");
+    const navigate = vi.fn();
+    openThreadInSplit({
+      store: { get: () => current, set: vi.fn() },
+      navigate,
+      projectId: "project-1",
+      threadId: "thread-2",
+      isCompact: false,
+      state: { searchMessageSeq: 7, searchThreadId: "thread-2" },
+    });
+
+    expect(navigate).toHaveBeenCalledWith(
+      "/projects/project-1/threads/thread-2",
+      {
+        replace: true,
+        state: { searchMessageSeq: 7, searchThreadId: "thread-2" },
+      },
+    );
+  });
+});

--- a/apps/app/src/lib/split-layout/openThreadInSplit.ts
+++ b/apps/app/src/lib/split-layout/openThreadInSplit.ts
@@ -19,10 +19,14 @@ interface SplitLayoutStore {
 
 interface OpenThreadInSplitArgs {
   store: SplitLayoutStore;
-  navigate: (route: string, options?: { replace?: boolean }) => void;
+  navigate: (
+    route: string,
+    options?: { replace?: boolean; state?: Record<string, unknown> },
+  ) => void;
   projectId: string;
   threadId: string;
   isCompact: boolean;
+  state?: Record<string, unknown>;
 }
 
 export function openThreadInSplit({
@@ -31,11 +35,12 @@ export function openThreadInSplit({
   projectId,
   threadId,
   isCompact,
+  state,
 }: OpenThreadInSplitArgs): void {
   const route = getThreadRoutePath({ projectId, threadId });
   const layout = store.get(splitLayoutAtom);
   if (isCompact || layout === null) {
-    navigate(route);
+    navigate(route, state === undefined ? undefined : { state });
     return;
   }
   const existing = findPaneByThread(layout.root, projectId, threadId);
@@ -44,7 +49,10 @@ export function openThreadInSplit({
     if (next !== layout) {
       store.set(splitLayoutAtom, next);
     }
-    navigate(route, { replace: true });
+    navigate(route, {
+      replace: true,
+      ...(state === undefined ? {} : { state }),
+    });
     return;
   }
   const decision = decideThreadDrop({
@@ -60,5 +68,5 @@ export function openThreadInSplit({
   if (next !== layout) {
     store.set(splitLayoutAtom, next);
   }
-  navigate(route);
+  navigate(route, state === undefined ? undefined : { state });
 }


### PR DESCRIPTION
## Human comments

## What was wrong

Thread search results could only replace the current view; users could not open a result beside their existing thread.

## What changed

- Open selected results in splits with Command/Control-Enter or the labeled “Open in split” row action.
- Preserve message-match anchors when opening a split.
- Group status with project metadata; reserve the right side for the selected-row action, without a footer hint.

## How you verified

- Head `1fdbcae3b`: [CI blocked by workspace-download timeout](https://github.com/get-bb/bb/actions/runs/35017001950/job/104543172276); the app-1 shard did not reach tests.
- Chrome for Testing 153: the selected result opens beside the current thread; the parent replaces the current view.
- Desktop and phone captures confirm status beside project metadata. Previously reviewed behavior; no additional code review.

### Desktop comparison

Fresh pixels from the exact source web app revisions below, using the same fixtures, route, selection and CSS viewport at 2× density. Desktop: 1440×900 CSS / 2880×1800 PNG. Phone: 390×844 CSS / 780×1688 PNG.

| State | Before — #3370 `15e439bec` | After — `1fdbcae3b` |
| --- | --- | --- |
| Search threads · before typing | ![middle-desktop-threads](https://github.com/user-attachments/assets/5850d268-5dfb-4954-8a42-0a2d6e3e32bd) | ![top-desktop-threads](https://github.com/user-attachments/assets/61dcd7ca-61ea-4509-afc7-616a2d321149) |
| Search threads · title, follow-up draft, archived and message results | ![middle-desktop-thread-matches](https://github.com/user-attachments/assets/91529b9d-2cdc-4061-8768-81314ddbf48b) | ![top-desktop-thread-matches](https://github.com/user-attachments/assets/d9e035b6-3f15-40e8-b020-19e6b7364b12) |
| Search threads · message match | ![middle-desktop-message-match](https://github.com/user-attachments/assets/848ae0bc-4226-4ce6-9fa4-363b261064b8) | ![top-desktop-message-match](https://github.com/user-attachments/assets/f908bbfc-235e-4166-813f-5ce045a8f94f) |

| State | Before — #3370 — replaces current view | After —  #3595 — opens beside current view |
| --- | --- | --- |
| Command-Enter on the selected thread result | ![middle-desktop-open-split](https://github.com/user-attachments/assets/44d7f1f8-b89b-4d08-9637-6c935935ac84) | ![top-desktop-open-split](https://github.com/user-attachments/assets/0a0f928e-57e0-4cd2-bd98-f9fb9f9e30b7) |

### Phone comparison

| State | Before — #3370 `15e439bec` | After — `1fdbcae3b` |
| --- | --- | --- |
| Search threads · before typing | ![middle-mobile-threads](https://github.com/user-attachments/assets/521e4cc2-d499-43e6-9a4f-a1a89d43724d) | ![top-mobile-threads](https://github.com/user-attachments/assets/41403080-9d25-4294-a069-66048ded93ca) |
| Search threads · title, follow-up draft, archived and message results | ![middle-mobile-thread-matches](https://github.com/user-attachments/assets/a5b71782-ad09-439f-bac2-a1f3b874d202) | ![top-mobile-thread-matches](https://github.com/user-attachments/assets/b1aa59bb-ddfd-4dfb-b537-5ebe5c929a85) |
| Search threads · message match | ![middle-mobile-message-match](https://github.com/user-attachments/assets/c902898d-f5d1-49fa-b2ea-ff47007183e4) | ![top-mobile-message-match](https://github.com/user-attachments/assets/ee626d7a-739f-455b-a7dd-50c17d3f9c13) |

The pencil marks an existing thread with an unsent follow-up, not a first-class saved draft resource. Message screenshots verify result rendering, not message-anchor landing. This PR remains draft while exact-head CI is incomplete.

BB-Thread-ID: thr_82jtfaq8eq

> AGENT GENERATED

